### PR TITLE
Add support for multiremote

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import WdioReporter from '@wdio/reporter';
 import allureReporter from '@wdio/allure-reporter';
-import mkdirp from 'mkdirp';
 import fs from 'fs-extra';
 import path from 'path';
 import { spawn } from 'child_process';
@@ -8,7 +7,6 @@ import { path as ffmpegPath} from '@ffmpeg-installer/ffmpeg';
 
 import helpers from './helpers.js';
 import config from './config.js';
-import notAvailableImage from './assets/not-available.png';
 
 export default class Video extends WdioReporter {
   /**
@@ -39,6 +37,9 @@ export default class Video extends WdioReporter {
     this.videos = [];
     this.config = config;
 
+    // If multiremote is enabled there may be multiple browsers
+    this.browsers = [];
+
     helpers.setLogger(msg => this.write(msg));
   }
 
@@ -55,6 +56,8 @@ export default class Video extends WdioReporter {
     config.debugMode = logLevel.toLowerCase() === 'trace' || logLevel.toLowerCase() === 'debug';
     this.write('Using reporter config:' + JSON.stringify(browser.config.reporters, undefined, 2) + '\n\n');
     this.write('Using config:' + JSON.stringify(config, undefined, 2) + '\n\n\n');
+    
+    this.browsers = helpers.getBrowsers(browser);
   }
 
   /**
@@ -71,17 +74,7 @@ export default class Video extends WdioReporter {
       return;
     }
 
-    const filename = this.frameNr.toString().padStart(4, '0') + '.png';
-    const filePath = path.resolve(this.recordingPath, filename);
-
-    try {
-      browser.saveScreenshot(filePath);
-      helpers.debugLog('- Screenshot!!\n');
-    } catch (e) {
-      fs.writeFile(filePath, notAvailableImage, 'base64');
-      helpers.debugLog('- Screenshot not available...\n');
-    }
-    this.frameNr++;
+    helpers.takeScreenshot(this.browsers);
   }
 
   /**
@@ -106,14 +99,9 @@ export default class Video extends WdioReporter {
     helpers.debugLog(`\n\n--- New test: ${test.title} ---\n`);
     this.testnameStructure.push(test.title.replace(/ /g, '-'));
     const fullname = this.testnameStructure.slice(1).reduce((cur,acc) => cur + '--' + acc, this.testnameStructure[0]);
-    let browserName = browser.capabilities.browserName.toUpperCase();
-    if (browser.capabilities.deviceType) {
-      browserName += `-${browser.capabilities.deviceType.replace(/ /g, '-')}`;
-    }
-    this.testname = helpers.generateFilename(browserName, fullname);
-    this.frameNr = 0;
-    this.recordingPath = path.resolve(config.outputDir, config.rawPath, this.testname);
-    mkdirp.sync(this.recordingPath);
+  
+    helpers.setBrowserAttributes(this.browsers, config, fullname);
+
   }
 
   /**
@@ -129,39 +117,36 @@ export default class Video extends WdioReporter {
   onTestEnd (test) {
     this.testnameStructure.pop();
 
-    if(config.usingAllure) {
-      if (browser.capabilities.deviceType) {
-        allureReporter.addArgument('deviceType', browser.capabilities.deviceType);
-      }
-      if (browser.capabilities.browserVersion) {
-        allureReporter.addArgument('browserVersion', browser.capabilities.browserVersion);
-      }
-    }
+    this.browsers.forEach(b => {
+        if(config.usingAllure) {
+          if (b.obj.capabilities.deviceType) {
+            allureReporter.addArgument('deviceType', b.obj.capabilities.deviceType);
+          }
+          if (b.obj.capabilities.browserVersion) {
+            allureReporter.addArgument('browserVersion', b.obj.capabilities.browserVersion);
+          }
+        }
+      });
 
     if (test.state === 'failed' || (test.state === 'passed' && config.saveAllVideos)) {
-      const filePath = path.resolve(this.recordingPath, this.frameNr.toString().padStart(4, '0') + '.png');
-      try {
-        browser.saveScreenshot(filePath);
-        helpers.debugLog('- Screenshot!!\n');
-      } catch (e) {
-        fs.writeFile(filePath, notAvailableImage, 'base64');
-        helpers.debugLog('- Screenshot not available...\n');
-      }
+      this.browsers.forEach(b => {
+          helpers.takeScreenshot([b]);
 
-      const videoPath = path.resolve(config.outputDir, this.testname + '.mp4');
-      this.videos.push(videoPath);
+          const videoPath = path.resolve(config.outputDir, b.testname + '.mp4');
+          this.videos.push(videoPath);
 
-      if (config.usingAllure) {
-        allureReporter.addAttachment('Execution video', videoPath, 'video/mp4');
-      }
+          if (config.usingAllure) {
+            allureReporter.addAttachment('Execution video', videoPath, 'video/mp4');
+          }
 
-      const command = `"${ffmpegPath}" -y -r 10 -i "${this.recordingPath}/%04d.png" -vcodec libx264` +
-        ` -crf 32 -pix_fmt yuv420p -vf "scale=1200:trunc(ow/a/2)*2","setpts=${config.videoSlowdownMultiplier}.0*PTS"` +
-        ` "${path.resolve(config.outputDir, this.testname)}.mp4"`;
+          const command = `"${ffmpegPath}" -y -r 10 -i "${b.recordingPath}/${b.name}-%04d.png" -vcodec libx264` +
+            ` -crf 32 -pix_fmt yuv420p -vf "scale=1200:trunc(ow/a/2)*2","setpts=${config.videoSlowdownMultiplier}.0*PTS"` +
+            ` "${path.resolve(config.outputDir, b.testname)}.mp4"`;
 
-      helpers.debugLog(`ffmpeg command: ${command}\n`);
+          helpers.debugLog(`ffmpeg command: ${command}\n`);
 
-      this.ffmpegCommands.push(command);
+          this.ffmpegCommands.push(command);
+        });
     }
   }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -170,7 +170,11 @@ describe('wdio-video-recorder - ', () => {
 
       it('command is not present in included JsonWireActions', () => {
         let video = new Video(options);
-        video.recordingPath = 'folder';
+        video.onRunnerStart(browser);
+        video.onTestStart({ title: 'TEST' });      
+        video.browsers.forEach(b => {
+          b.recordingPath = 'folder';
+        });
         video.onAfterCommand({ endpoint: '/session/abcdef/piripiri' });
         expect(video.frameNr).toBe(0);
       });
@@ -178,7 +182,11 @@ describe('wdio-video-recorder - ', () => {
       it('command is present in excluded JsonWireActions', () => {
         options.addExcludedActions = [originalConfig.jsonWireActions[0]];
         let video = new Video(options);
-        video.recordingPath = 'folder';
+        video.onRunnerStart(browser);
+        video.onTestStart({ title: 'TEST' });      
+        video.browsers.forEach(b => {
+          b.recordingPath = 'folder';
+        });
         video.onAfterCommand({ endpoint: '/session/abcdef/' + originalConfig.jsonWireActions[0] });
         expect(video.frameNr).toBe(0);
       });
@@ -186,7 +194,11 @@ describe('wdio-video-recorder - ', () => {
       it('regexp fails to identify command', () => {
         options.addExcludedActions = [originalConfig.jsonWireActions[0]];
         let video = new Video(options);
-        video.recordingPath = 'folder';
+        video.onRunnerStart(browser);
+        video.onTestStart({ title: 'TEST' });      
+        video.browsers.forEach(b => {
+          b.recordingPath = 'folder';
+        });
         video.onAfterCommand({ endpoint: '/nothing-to-see-here/' });
         expect(video.frameNr).toBe(0);
       });
@@ -195,8 +207,11 @@ describe('wdio-video-recorder - ', () => {
     describe('should create video frame when -', () => {
       it('command is present in included JsonWireActions', () => {
         let video = new Video(options);
-        video.recordingPath = 'folder';
-
+        video.onRunnerStart(browser);
+        video.onTestStart({ title: 'TEST' });      
+        video.browsers.forEach(b => {
+          b.recordingPath = 'folder';
+        });
         video.onAfterCommand({ endpoint: '/session/abcdef/' + originalConfig.jsonWireActions[0] });
         expect(browser.saveScreenshot).toHaveBeenCalledWith('folder/0000.png');
 
@@ -261,33 +276,49 @@ describe('wdio-video-recorder - ', () => {
 
     it('should reset frameNr', () => {
       let video = new Video(options);
-      video.frameNr = 42;
+      video.browsers.forEach(b => {
+        b.frameNr = 42;
+      });
       video.onTestStart({ title: 'TEST' });
-      expect(video.frameNr).toEqual(0);
+      video.browsers.forEach(b => {
+        expect(b.frameNr).toEqual(0);
+      });
     });
 
     it('should generate testname', () => {
       helpers.default.generateFilename = jest.fn().mockImplementationOnce(() => 'TEST-NAME');
 
       let video = new Video(options);
-      video.testname = undefined;
-      video.onTestStart({ title: 'TEST' });
-      expect(video.testname).not.toEqual(undefined);
-      expect(helpers.default.generateFilename).toHaveBeenCalled();
+      video.onRunnerStart(browser);
+      video.browsers.forEach(b => {
+        b.testname = undefined;
+      });      
+      video.onTestStart({ title: 'TEST' });      
+      video.browsers.forEach(b => {
+        expect(b.testname).not.toEqual(undefined);
+        expect(helpers.default.generateFilename).toHaveBeenCalled();
+      });            
     });
 
     it('should append deviceType to browsername', () => {
       helpers.default.generateFilename = jest.fn();
       let video = new Video(options);
-      video.testname = undefined;
-      video.onTestStart({ title: 'TEST' });
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });      
+      video.browsers.forEach(b => {
+        b.testname = undefined;
+      });      
       expect(helpers.default.generateFilename).toHaveBeenCalledWith('BROWSER', 'TEST');
 
       helpers.default.generateFilename = jest.fn();
-      global.browser.capabilities.deviceType = 'myDevice';
+      
       video = new Video(options);
-      video.testname = undefined;
+      video.onRunnerStart(browser);
+      video.browsers.forEach(b => {
+        b.obj.capabilities.deviceType = 'myDevice';
+      });
       video.onTestStart({ title: 'TEST' });
+
       expect(helpers.default.generateFilename).toHaveBeenCalledWith('BROWSER-myDevice', 'TEST');
     });
 
@@ -296,7 +327,9 @@ describe('wdio-video-recorder - ', () => {
 
       let video = new Video(options);
       video.onTestStart({ title: 'TEST' });
-      expect(video.recordingPath).toEqual(outputDir + '/' + originalConfig.rawPath + '/' + 'TEST-NAME');
+      video.browsers.forEach(b => {
+        expect(b.recordingPath).toEqual(outputDir + '/' + originalConfig.rawPath + '/' + 'TEST-NAME');
+      });
     });
 
     it('should set recordingpath when outputDir is not configured', () => {
@@ -304,7 +337,9 @@ describe('wdio-video-recorder - ', () => {
 
       let video = new Video(options);
       video.onTestStart({ title: 'TEST' });
-      expect(video.recordingPath).toEqual(configModule.default.outputDir + '/' + originalConfig.rawPath + '/' + 'TEST-NAME');
+      video.browsers.forEach(b => {
+        expect(b.recordingPath).toEqual(configModule.default.outputDir + '/' + originalConfig.rawPath + '/' + 'TEST-NAME');
+      });
     });
   });
 
@@ -335,17 +370,23 @@ describe('wdio-video-recorder - ', () => {
       allureMocks.addAttachment = jest.fn();
       options.saveAllVideos = true;
       video = new Video(options);
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });      
       video.onTestEnd({ title: 'TEST', state: 'passed' });
       expect(allureMocks.addAttachment).not.toHaveBeenCalled();
 
       allureMocks.addAttachment = jest.fn();
       video = new Video(options);
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });      
       video.config.usingAllure = true;
       video.onTestEnd({ title: 'TEST', state: 'failed' });
       expect(allureMocks.addAttachment).toHaveBeenCalled();
 
       allureMocks.addAttachment = jest.fn();
       video = new Video(options);
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });      
       video.config.usingAllure = true;
       video.onTestEnd({ title: 'TEST', state: 'failed' });
       expect(allureMocks.addAttachment).toHaveBeenCalled();
@@ -359,53 +400,71 @@ describe('wdio-video-recorder - ', () => {
     });
 
     it('should add deviceType as argument to allure', () => {
-      global.browser.capabilities.deviceType = 'myDevice';
-
+      let video = new Video(options);
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });
+      video.browsers.forEach(b => {
+        b.obj.capabilities.deviceType = 'myDevice';
+      });
       configModule.default.usingAllure = false;
       allureMocks.addArgument = jest.fn();
-      let video = new Video(options);
-      video.testname = undefined;
       video.onTestEnd({ title: 'TEST', state: 'passed' });
       expect(allureMocks.addArgument).not.toHaveBeenCalled();
 
+      video = new Video(options);
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });
+      video.browsers.forEach(b => {
+        b.obj.capabilities.deviceType = 'myDevice';
+      });
       configModule.default.usingAllure = true;
       allureMocks.addArgument = jest.fn();
-      video = new Video(options);
-      video.testname = undefined;
       video.onTestEnd({ title: 'TEST', state: 'passed' });
       expect(allureMocks.addArgument).toHaveBeenCalledWith('deviceType', 'myDevice');
     });
 
     it('should add browserVersion as argument to allure', () => {
-      global.browser.capabilities.browserVersion = '1.2.3';
-
       configModule.default.usingAllure = false;
       allureMocks.addArgument = jest.fn();
       let video = new Video(options);
-      video.testname = undefined;
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });
+      video.browsers.forEach(b => {
+        b.testname = undefined;
+      });
       video.onTestEnd({ title: 'TEST', state: 'passed' });
       expect(allureMocks.addArgument).not.toHaveBeenCalled();
 
-      configModule.default.usingAllure = true;
       allureMocks.addArgument = jest.fn();
       video = new Video(options);
-      video.testname = undefined;
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });
+      configModule.default.usingAllure = true;
+      video.browsers.forEach(b => {
+        b.obj.capabilities.browserVersion = '1.2.3';
+      });
       video.onTestEnd({ title: 'TEST', state: 'passed' });
       expect(allureMocks.addArgument).toHaveBeenCalledWith('browserVersion', '1.2.3');
     });
 
     it('should not take a last screenshot if test passed', () => {
       let video = new Video(options);
-      video.recordingPath = 'folder';
-
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });
+      video.browsers.forEach(b => {
+        b.recordingPath = 'folder';
+      });
       video.onTestEnd({ title: 'TEST', state: 'passed' });
       expect(browser.saveScreenshot).not.toHaveBeenCalledWith('folder/0000.png');
     });
 
     it('should take a last screenshot if test failed', () => {
       let video = new Video(options);
-      video.recordingPath = 'folder';
-
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });
+      video.browsers.forEach(b => {
+        b.recordingPath = 'folder';
+      });   
       video.onTestEnd({ title: 'TEST', state: 'failed' });
       expect(browser.saveScreenshot).toHaveBeenCalledWith('folder/0000.png');
     });
@@ -413,8 +472,11 @@ describe('wdio-video-recorder - ', () => {
     it('should take a last screenshot if test passed and config saveAllvideos', () => {
       options.saveAllVideos = true;
       let video = new Video(options);
-      video.recordingPath = 'folder';
-
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });
+      video.browsers.forEach(b => {
+        b.recordingPath = 'folder';
+      });      
       video.onTestEnd({ title: 'TEST', state: 'passed' });
       expect(browser.saveScreenshot).toHaveBeenCalledWith('folder/0000.png');
     });
@@ -422,8 +484,12 @@ describe('wdio-video-recorder - ', () => {
     it('should write notAvailable.png as last screenshot if saveScreenshot fails', () => {
       browser.saveScreenshot.mockImplementationOnce(() => { throw 'error'; });
       let video = new Video(options);
-      video.recordingPath = 'folder';
-
+      
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });
+      video.browsers.forEach(b => {
+        b.recordingPath = 'folder';
+      });
       video.onTestEnd({ title: 'TEST', state: 'failed' });
       expect(fsMocks.writeFile).toHaveBeenCalledWith('folder/0000.png', 'file-mock', 'base64');
     });
@@ -449,6 +515,8 @@ describe('wdio-video-recorder - ', () => {
     it('should spawn ffmpeg when tests fail', () => {
       let video = new Video(options);
 
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });
       video.onTestEnd({ title: 'TEST', state: 'failed' });
       video.onRunnerEnd();
       expect(cpMocks.spawn).toHaveBeenCalled();
@@ -458,6 +526,8 @@ describe('wdio-video-recorder - ', () => {
       options.saveAllVideos = true;
       let video = new Video(options);
 
+      video.onRunnerStart(browser);
+      video.onTestStart({ title: 'TEST' });
       video.onTestEnd({ title: 'TEST', state: 'passed' });
       video.onRunnerEnd();
       expect(cpMocks.spawn).toHaveBeenCalled();


### PR DESCRIPTION
Webdriverio has a feature called multiremote https://webdriver.io/docs/multiremote.html
It allows to drive multiple browsers at the same time

This pr adds support for multiremote.

There doesn't appear to be a way to easily fetch browser instances, so this pr checks for `isMultiremote` and gets the names of those browser. It then calls saveScreenshot assume a global var exists with that same name

I can tidy up this further, particularly the objects created in `getBrowsers`. It also needs some further testing.

I wanted to get some feedback before proceeding further?