### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,11 @@ export default class Video extends WdioReporter {
     const filename = this.frameNr.toString().padStart(4, '0') + '.png';
     const filePath = path.resolve(this.recordingPath, filename);
 
+    // Create the report directory, if it does not exists
+    if (!fs.existsSync(filePath)) {
+      fs.mkdirSync(filePath);
+    }
+    
     try {
       this.screenshotPromises.push(
         browser.saveScreenshot(filePath).then(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -103,8 +103,8 @@ export default class Video extends WdioReporter {
     const filePath = path.resolve(this.recordingPath, filename);
 
     // Create the report directory, if it does not exists
-    if (!fs.existsSync(filePath)) {
-      fs.mkdirSync(filePath);
+    if (!fs.existsSync(this.recordingPath)) {
+      fs.mkdirSync(this.recordingPath);
     }
     
     try {


### PR DESCRIPTION
When the wdio runners is on concurrent execution mode, the below errors are thrown in the console logs and it does not generate the video report. The proposed change address the mentioned issue by creating the directory, if it does not exists.

 Error: directory (/local/testruns/e8f1acd4-79d5-44e2-a331-08b9472a6821/src/TestSuiteJS/build/integ-tests/video/rawSeleniumVideoGrabs/Authoring-Field-Link--List-rowlink--Should-remove-the-link-when-unmapping-the-slot--CHROME--11-23-2021--21-03-00-304) doesn't exist
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at Video.onAfterCommand (/local/testruns/e8f1acd4-79d5-44e2-a331-08b9472a6821/src/TestSuiteJS/node_modules/wdio-video-reporter/src/index.js:103:17)
    at //local/testruns/e8f1acd4-79d5-44e2-a331-08b9472a6821/src/TestSuiteJS/node_modules/@wdio/runner/build/reporter.js:38:49
    at Array.forEach (<anonymous>)
    at BaseReporter.emit (/local/testruns/e8f1acd4-79d5-44e2-a331-08b9472a6821/src/TestSuiteJS/node_modules/@wdio/runner/build/reporter.js:38:20)
    at EventEmitter.<anonymous> (/local/testruns/e8f1acd4-79d5-44e2-a331-08b9472a6821/src/TestSuiteJS/node_modules/@wdio/runner/build/index.js:202:50)
    at Browser.WebDriver.prototype.<computed> [as emit] (/local/testruns/e8f1acd4-79d5-44e2-a331-08b9472a6821/src/TestSuiteJS/node_modules/@wdio/utils/build/monad.js:130:3