### PR TITLE
Create the recordingPath directory, if the recordingPath does not exists

### DIFF
--- a/__mocks__/fs-extra.js
+++ b/__mocks__/fs-extra.js
@@ -6,6 +6,7 @@ export const resetFsMocks = () => {
     removeSync: jest.fn(),
     writeFile: jest.fn(),
     existsSync: jest.fn().mockReturnValue('MOCK'),
+    mkdirsSync: jest.fn(),
     readFileSync: jest.fn()
       .mockReturnValueOnce('outputDir/MOCK-VIDEO-1.mp4')
       .mockReturnValueOnce('outputDir/MOCK-VIDEO-1.mp4')
@@ -24,6 +25,7 @@ export default {
   copySync(...args) { fsMocks.copySync(...args); },
   removeSync(...args) { fsMocks.removeSync(...args); },
   existsSync(...args) { return fsMocks.existsSync(...args); },
+  mkdirsSync(...args) { fsMocks.mkdirsSync(...args); },
   readFileSync(...args) { return fsMocks.readFileSync(...args); },
   readdirSync(...args) { return fsMocks.readdirSync(...args); },
   statSync(...args) { return fsMocks.statSync(...args); },

--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,12 @@ export default class Video extends WdioReporter {
     const filename = this.frameNr.toString().padStart(4, '0') + '.png';
     const filePath = path.resolve(this.recordingPath, filename);
 
+    // Create the report directory, if it does not exists
+    if (!fs.existsSync(this.recordingPath)) {
+      helpers.debugLog(`Creating: ${this.recordingPath}, as it not exists...\n`);
+      fs.mkdirsSync(this.recordingPath);
+    }
+
     try {
       this.screenshotPromises.push(
         browser.saveScreenshot(filePath).then(() => {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -329,6 +329,31 @@ describe('wdio-video-recorder - ', () => {
         video.onAfterCommand({endpoint: '/nothing-to-see-here/'});
         expect(video.frameNr).toBe(0);
       });
+
+      it('should not create recordingPath if exists', (done) => {
+        let video = new Video(options);
+        video.recordingPath = 'folder';
+        helpers.default.debugLog = jest.fn();
+        fsMocks.existsSync = jest.fn().mockReturnValue(true);
+        video.onAfterCommand({endpoint: '/session/abcdef/' + originalConfig.jsonWireActions[0]});
+        setImmediate(() => {
+          expect(fsMocks.mkdirsSync).toBeCalledTimes(0);
+          done();
+        });
+      });
+
+      it('should create recordingPath if not exists', (done) => {
+        let video = new Video(options);
+        video.recordingPath = 'folder';
+        helpers.default.debugLog = jest.fn();
+        fsMocks.existsSync = jest.fn().mockReturnValue(false);
+        video.onAfterCommand({endpoint: '/session/abcdef/' + originalConfig.jsonWireActions[0]});
+        setImmediate(() => {
+          expect(fsMocks.mkdirsSync).toBeCalledTimes(1);
+          done();
+        });
+      });
+
     });
 
     describe('should create video frame when -', () => {


### PR DESCRIPTION
When the wdio runners is on concurrent execution mode, the below errors are thrown in the console logs and it does not generate the video report. The proposed change address the mentioned issue by creating the directory, if it does not exists.

 Error: directory (/local/testruns/e8f1acd4-79d5-44e2-a331-08b9472a6821/src/TestSuiteJS/build/integ-tests/video/rawSeleniumVideoGrabs/Authoring-Field-Link--List-rowlink--Should-remove-the-link-when-unmapping-the-slot--CHROME--11-23-2021--21-03-00-304) doesn't exist
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at Video.onAfterCommand (/local/testruns/e8f1acd4-79d5-44e2-a331-08b9472a6821/src/TestSuiteJS/node_modules/wdio-video-reporter/src/index.js:103:17)
    at //local/testruns/e8f1acd4-79d5-44e2-a331-08b9472a6821/src/TestSuiteJS/node_modules/@wdio/runner/build/reporter.js:38:49
    at Array.forEach (<anonymous>)
    at BaseReporter.emit (/local/testruns/e8f1acd4-79d5-44e2-a331-08b9472a6821/src/TestSuiteJS/node_modules/@wdio/runner/build/reporter.js:38:20)
    at EventEmitter.<anonymous> (/local/testruns/e8f1acd4-79d5-44e2-a331-08b9472a6821/src/TestSuiteJS/node_modules/@wdio/runner/build/index.js:202:50)
    at Browser.WebDriver.prototype.<computed> [as emit] (/local/testruns/e8f1acd4-79d5-44e2-a331-08b9472a6821/src/TestSuiteJS/node_modules/@wdio/utils/build/monad.js:130:3