### PR TITLE
support nice-html-reporter by sending video-capture event at appropri…

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,31 @@ Adding the Allure reporter as well, automatically updates the reports with video
   ],
 ```
 
+Using with wdio-html-nice-reporter (https://github.com/rpii/wdio-html-reporter)
+-----------------
+
+Adding the html nice reporter automatically updates the reports with videos without any need to configure anything :-)
+
+```
+ reporters: [
+    [video, {
+      saveAllVideos: false,       // If true, also saves videos for successful test cases
+      videoSlowdownMultiplier: 3, // Higher to get slower videos, lower for faster videos [Value 1-100]
+      outputDir: './reports/html-reports/',
+    }],
+    ['html-nice', {
+          outputDir: './reports/html-reports/',
+          filename: 'report.html',
+          reportTitle: 'Test Report Title',
+          linkScreenshots: true,
+          //to show the report in a browser when done
+          showInBrowser: true,
+          collapseTests: false,
+          //to turn on screenshots after every test must be false to use video
+          useOnAfterCommandForScreenshot: false,
+    }],
+  ],
+```
 
 Configuration
 =============

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -56,6 +56,9 @@ export default {
     const videoPath = path.resolve(config.outputDir, this.testname + '.mp4');
     this.videos.push(videoPath);
 
+    //send event to nice-html-reporter
+    process.emit('test:video-capture', videoPath);
+
     if (config.usingAllure) {
       allureReporter.addAttachment('Execution video', videoPath, 'video/mp4');
     }


### PR DESCRIPTION
This pull request adds code to fire an event that nice-html-reporter receives and allows it to capture each video that is created by the wdio-video-reporter.  low risk change.  
Works with version 7.9.1 of nice-html-reporter  (git@github.com:rpii/wdio-html-reporter.git)