### PR TITLE
Fix for wdio-video-reporter with multi remote wdio

### DIFF
--- a/src/frameworks/cucumber.js
+++ b/src/frameworks/cucumber.js
@@ -45,9 +45,7 @@ export default {
 
       let browserName = 'browser';
 
-      const capabilities = this.isMultiremote
-      ? this.capabilities[Object.keys(this.capabilities)[0]]
-      : this.capabilities;
+      const capabilities = helpers.getCurrentCapabilities(this);
 
       if(capabilities.browserName) {
         browserName = capabilities.browserName.toUpperCase();
@@ -72,9 +70,7 @@ export default {
    */
   onSuiteEnd (suite) {
     if (config.usingAllure) {
-      const capabilities = this.isMultiremote
-      ? this.capabilities[Object.keys(this.capabilities)[0]]
-      : this.capabilities;
+      const capabilities = helpers.getCurrentCapabilities(this);
 
       if (capabilities.deviceType) {
         allureReporter.addArgument('deviceType', capabilities.deviceType);

--- a/src/frameworks/cucumber.js
+++ b/src/frameworks/cucumber.js
@@ -44,14 +44,19 @@ export default {
       const fullname = this.testnameStructure.slice(1).reduce((cur, acc) => cur + '--' + acc, this.testnameStructure[0]);
 
       let browserName = 'browser';
-      if(browser.capabilities.browserName) {
-        browserName = browser.capabilities.browserName.toUpperCase();
-      } else if(browser.capabilities.deviceName) {
-        browserName = `${browser.capabilities.deviceName.toUpperCase()}-${browser.capabilities.platformName.toUpperCase()}`;
+
+      const capabilities = this.isMultiremote
+      ? this.capabilities[Object.keys(this.capabilities)[0]]
+      : this.capabilities;
+
+      if(capabilities.browserName) {
+        browserName = capabilities.browserName.toUpperCase();
+      } else if(capabilities.deviceName) {
+        browserName = `${capabilities.deviceName.toUpperCase()}-${capabilities.platformName.toUpperCase()}`;
       }
 
-      if (browser.capabilities.deviceType) {
-        browserName += `-${browser.capabilities.deviceType.replace(/ /g, '-')}`;
+      if (capabilities.deviceType) {
+        browserName += `-${capabilities.deviceType.replace(/ /g, '-')}`;
       }
       this.testname = helpers.generateFilename(browserName, fullname);
       this.frameNr = 0;
@@ -67,11 +72,15 @@ export default {
    */
   onSuiteEnd (suite) {
     if (config.usingAllure) {
-      if (browser.capabilities.deviceType) {
-        allureReporter.addArgument('deviceType', browser.capabilities.deviceType);
+      const capabilities = this.isMultiremote
+      ? this.capabilities[Object.keys(this.capabilities)[0]]
+      : this.capabilities;
+
+      if (capabilities.deviceType) {
+        allureReporter.addArgument('deviceType', capabilities.deviceType);
       }
-      if (browser.capabilities.browserVersion) {
-        allureReporter.addArgument('browserVersion', browser.capabilities.browserVersion);
+      if (capabilities.browserVersion) {
+        allureReporter.addArgument('browserVersion', capabilities.browserVersion);
       }
     }
 

--- a/src/frameworks/cucumber.spec.js
+++ b/src/frameworks/cucumber.spec.js
@@ -180,6 +180,28 @@ describe('wdio-video-recorder - cucumber framework - ', () => {
         video.onSuiteStart({title: 'TEST123', type: 'scenario'});
         expect(helpers.default.generateFilename).toHaveBeenCalledWith('DEVICE-PLATFORM', 'TEST123');
       });
+
+      it('should figure out if multi remote is not being used', () => {
+        let video = new Video(options);
+        video.onSuiteStart({title: 'TEST', type: 'scenario'});
+        expect(video.isMultiremote).toBeFalsy();
+
+        video = new Video(options);
+        video.isMultiremote = true;
+        video.onSuiteStart({title: 'TEST', type: 'scenario'});
+        expect(video.isMultiremote).toBeTruthy();
+      });
+
+      it('should set capabilities in  both non-multiremote and multi remote', () => {
+        let video = new Video(options);
+        video.onSuiteStart({title: 'TEST', type: 'scenario'});
+        expect(video.capabilities).toBeDefined();
+
+        video = new Video(options);
+        video.isMultiremote = true;
+        video.onSuiteStart({title: 'TEST', type: 'scenario'});
+        expect(video.capabilities).toBeDefined();
+      });
     });
 
     describe('feature - ', () => {
@@ -333,6 +355,28 @@ describe('wdio-video-recorder - cucumber framework - ', () => {
 
         video.onSuiteEnd(passedScenario);
         expect(helpers.default.generateVideo).toHaveBeenCalled();
+      });
+
+      it('should figure out if multi remote is not being used', () => {
+        let video = new Video(options);
+        video.onSuiteStart({title: 'TEST', type: 'scenario'});
+        expect(video.isMultiremote).toBeFalsy();
+
+        video = new Video(options);
+        video.isMultiremote = true;
+        video.onSuiteStart({title: 'TEST', type: 'scenario'});
+        expect(video.isMultiremote).toBeTruthy();
+      });
+
+      it('should set capabilities in  both non-multiremote and multi remote', () => {
+        let video = new Video(options);
+        video.onSuiteStart({title: 'TEST', type: 'scenario'});
+        expect(video.capabilities).toBeDefined();
+
+        video = new Video(options);
+        video.isMultiremote = true;
+        video.onSuiteStart({title: 'TEST', type: 'scenario'});
+        expect(video.capabilities).toBeDefined();
       });
     });
 

--- a/src/frameworks/cucumber.spec.js
+++ b/src/frameworks/cucumber.spec.js
@@ -30,6 +30,10 @@ describe('wdio-video-recorder - cucumber framework - ', () => {
       this.frameNr = 0;
       this.videos = [];
       this.config = configModule.default;
+      this.capabilities = {
+        browserName: 'BROWSER',
+      },
+      this.isMultiremote = false;
     }
     onSuiteStart (suite) {
       cucumber.onSuiteStart.call(this, suite);
@@ -129,8 +133,8 @@ describe('wdio-video-recorder - cucumber framework - ', () => {
         expect(helpers.default.generateFilename).toHaveBeenCalledWith('BROWSER', 'TEST');
 
         helpers.default.generateFilename = jest.fn();
-        global.browser.capabilities.deviceType = 'myDevice';
         video = new Video(options);
+        video.capabilities.deviceType = 'myDevice';
         video.testname = undefined;
         video.onSuiteStart({title: 'TEST', type: 'scenario'});
         expect(helpers.default.generateFilename).toHaveBeenCalledWith('BROWSER-myDevice', 'TEST');
@@ -164,12 +168,12 @@ describe('wdio-video-recorder - cucumber framework - ', () => {
 
       it('should handle native appium tests', () => {
         let video = new Video(options);
-        video.framework = {
-          onSuiteStart: jest.fn(),
-        };
-        global.browser.capabilities = {
+        video.capabilities = {
           deviceName: 'DEVICE',
           platformName: 'PLATFORM',
+        };
+        video.framework = {
+          onSuiteStart: jest.fn(),
         };
 
         helpers.default.generateFilename = jest.fn().mockImplementationOnce(() => '');
@@ -232,11 +236,11 @@ describe('wdio-video-recorder - cucumber framework - ', () => {
       };
 
       it('should add deviceType as argument to allure', () => {
-        global.browser.capabilities.deviceType = 'myDevice';
 
         configModule.default.usingAllure = false;
         allureMocks.addArgument = jest.fn();
         let video = new Video(options);
+        video.capabilities.deviceType = 'myDevice';
         video.testname = undefined;
         video.onSuiteEnd(passedScenario);
         expect(allureMocks.addArgument).not.toHaveBeenCalled();
@@ -244,17 +248,18 @@ describe('wdio-video-recorder - cucumber framework - ', () => {
         configModule.default.usingAllure = true;
         allureMocks.addArgument = jest.fn();
         video = new Video(options);
+        video.capabilities.deviceType = 'myDevice';
         video.testname = undefined;
         video.onSuiteEnd(passedScenario);
         expect(allureMocks.addArgument).toHaveBeenCalledWith('deviceType', 'myDevice');
       });
 
       it('should add browserVersion as argument to allure', () => {
-        global.browser.capabilities.browserVersion = '1.2.3';
 
         configModule.default.usingAllure = false;
         allureMocks.addArgument = jest.fn();
         let video = new Video(options);
+        video.capabilities.browserVersion = '1.2.3';
         video.testname = undefined;
         video.onSuiteEnd(passedScenario);
         expect(allureMocks.addArgument).not.toHaveBeenCalled();
@@ -262,6 +267,7 @@ describe('wdio-video-recorder - cucumber framework - ', () => {
         configModule.default.usingAllure = true;
         allureMocks.addArgument = jest.fn();
         video = new Video(options);
+        video.capabilities.browserVersion = '1.2.3';
         video.testname = undefined;
         video.onSuiteEnd(passedScenario);
         expect(allureMocks.addArgument).toHaveBeenCalledWith('browserVersion', '1.2.3');

--- a/src/frameworks/default.js
+++ b/src/frameworks/default.js
@@ -57,9 +57,8 @@ export default {
     const fullname = this.testnameStructure.slice(1).reduce((cur, acc) => cur + '--' + acc, this.testnameStructure[0]);
 
     let browserName = 'browser';
-    const capabilities = this.isMultiremote
-      ? this.capabilities[Object.keys(this.capabilities)[0]]
-      : this.capabilities;
+    const capabilities = helpers.getCurrentCapabilities(this);
+
 
     if(capabilities.browserName) {
     browserName = capabilities.browserName.toUpperCase();

--- a/src/frameworks/default.js
+++ b/src/frameworks/default.js
@@ -57,14 +57,18 @@ export default {
     const fullname = this.testnameStructure.slice(1).reduce((cur, acc) => cur + '--' + acc, this.testnameStructure[0]);
 
     let browserName = 'browser';
-    if(browser.capabilities.browserName) {
-      browserName = browser.capabilities.browserName.toUpperCase();
-    } else if(browser.capabilities.deviceName) {
-      browserName = `${browser.capabilities.deviceName.toUpperCase()}-${browser.capabilities.platformName.toUpperCase()}`;
+    const capabilities = this.isMultiremote
+      ? this.capabilities[Object.keys(this.capabilities)[0]]
+      : this.capabilities;
+
+    if(capabilities.browserName) {
+    browserName = capabilities.browserName.toUpperCase();
+    } else if(capabilities.deviceName) {
+      browserName = `${capabilities.deviceName.toUpperCase()}-${capabilities.platformName.toUpperCase()}`;
     }
 
-    if (browser.capabilities.deviceType) {
-      browserName += `-${browser.capabilities.deviceType.replace(/ /g, '-')}`;
+    if (capabilities.deviceType) {
+      browserName += `-${capabilities.deviceType.replace(/ /g, '-')}`;
     }
     this.testname = helpers.generateFilename(browserName, fullname);
     this.frameNr = 0;

--- a/src/frameworks/default.js
+++ b/src/frameworks/default.js
@@ -61,7 +61,7 @@ export default {
 
 
     if(capabilities.browserName) {
-    browserName = capabilities.browserName.toUpperCase();
+      browserName = capabilities.browserName.toUpperCase();
     } else if(capabilities.deviceName) {
       browserName = `${capabilities.deviceName.toUpperCase()}-${capabilities.platformName.toUpperCase()}`;
     }

--- a/src/frameworks/default.spec.js
+++ b/src/frameworks/default.spec.js
@@ -124,6 +124,23 @@ describe('wdio-video-recorder - default framework - ', () => {
       expect(helpers.default.generateFilename).toHaveBeenCalledWith('BROWSER-myDevice', 'TEST');
     });
 
+    it('should append deviceName to platformName', () => {
+      helpers.default.generateFilename = jest.fn();
+      let video = new Video(options);
+      video.testname = undefined;
+      video.onTestStart({title: 'TEST'});
+      expect(helpers.default.generateFilename).toHaveBeenCalledWith('BROWSER', 'TEST');
+
+      helpers.default.generateFilename = jest.fn();
+      video = new Video(options);
+      video.capabilities.browserName = undefined;
+      video.capabilities.deviceName = 'myDevice';
+      video.capabilities.platformName = 'myPlatform';
+      video.testname = undefined;
+      video.onTestStart({title: 'TEST'});
+      expect(helpers.default.generateFilename).toHaveBeenCalledWith('MYDEVICE-MYPLATFORM', 'TEST');
+    });
+
     it('should set recordingpath', () => {
       helpers.default.generateFilename = jest.fn().mockImplementationOnce(() => 'TEST-NAME');
 
@@ -152,6 +169,29 @@ describe('wdio-video-recorder - default framework - ', () => {
       helpers.default.generateFilename = jest.fn().mockImplementationOnce(() => '');
       video.onTestStart({title: 'TEST123'});
       expect(helpers.default.generateFilename).toHaveBeenCalledWith('DEVICE-PLATFORM', 'TEST123');
+    });
+
+    it('should figure out if multi remote is not being used', () => {
+      let video = new Video(options);
+      video.onTestStart({title: 'TEST'});
+      expect(video.isMultiremote).toBeFalsy();
+
+      video = new Video(options);
+      video.isMultiremote = true;
+      video.onTestStart({title: 'TEST'});
+      expect(video.isMultiremote).toBeTruthy();
+    });
+
+    it('should set capabilities in  both non-multiremote and multi remote', () => {
+      let video = new Video(options);
+      video.onTestStart({title: 'TEST'});
+      expect(video.capabilities).toBeDefined();
+
+      video = new Video(options);
+      video.isMultiremote = true;
+      video.onTestStart({title: 'TEST'});
+      expect(video.capabilities).toBeDefined();
+
     });
   });
 

--- a/src/frameworks/default.spec.js
+++ b/src/frameworks/default.spec.js
@@ -27,6 +27,10 @@ describe('wdio-video-recorder - default framework - ', () => {
       this.testname = '';
       this.frameNr = 0;
       this.videos = [];
+      this.capabilities = {
+        browserName: 'BROWSER',
+      },
+      this.isMultiremote = false;
     }
     onTestStart (test) {
       defaultFramework.onTestStart.call(this, test);
@@ -113,8 +117,8 @@ describe('wdio-video-recorder - default framework - ', () => {
       expect(helpers.default.generateFilename).toHaveBeenCalledWith('BROWSER', 'TEST');
 
       helpers.default.generateFilename = jest.fn();
-      global.browser.capabilities.deviceType = 'myDevice';
       video = new Video(options);
+      video.capabilities.deviceType = 'myDevice';
       video.testname = undefined;
       video.onTestStart({title: 'TEST'});
       expect(helpers.default.generateFilename).toHaveBeenCalledWith('BROWSER-myDevice', 'TEST');
@@ -138,14 +142,13 @@ describe('wdio-video-recorder - default framework - ', () => {
 
     it('should handle native appium tests', () => {
       let video = new Video(options);
-      video.framework = {
-        onSuiteStart: jest.fn(),
-      };
-      global.browser.capabilities = {
+      video.capabilities = {
         deviceName: 'DEVICE',
         platformName: 'PLATFORM',
       };
-
+      video.framework = {
+        onSuiteStart: jest.fn(),
+      };
       helpers.default.generateFilename = jest.fn().mockImplementationOnce(() => '');
       video.onTestStart({title: 'TEST123'});
       expect(helpers.default.generateFilename).toHaveBeenCalledWith('DEVICE-PLATFORM', 'TEST123');

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -131,4 +131,10 @@ export default {
     } while(new Date().getTime() < abortTime && !allConstant);
   },
 
+  getCurrentCapabilities (videoReporterObject) {
+    const currentCapabilities = videoReporterObject.isMultiremote
+      ? videoReporterObject.capabilities[Object.keys(videoReporterObject.capabilities)[0]]
+      : videoReporterObject.capabilities;
+    return currentCapabilities;
+  },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -77,9 +77,9 @@ export default class Video extends WdioReporter {
       : runner.sessionId;
     this.sessionId = sessionId;
 
-    const runnerInstance = runner.isMultiremote ?
-      runner.instanceOptions[sessionId[0]]
-    : runner.instanceOptions[sessionId];
+    const runnerInstance = runner.isMultiremote
+      ? runner.instanceOptions[sessionId[0]]
+      : runner.instanceOptions[sessionId];
     this.runnerInstance = runnerInstance;
 
     const allureConfig = runnerInstance.reporters.filter(r => r === 'allure' || r[0] === 'allure').pop();
@@ -179,9 +179,7 @@ export default class Video extends WdioReporter {
 
     if(config.usingAllure) {
 
-      const capabilities = this.isMultiremote
-      ? this.capabilities[Object.keys(this.capabilities)[0]]
-      : this.capabilities;
+      const capabilities = helpers.getCurrentCapabilities(this);
 
       if (capabilities.deviceType) {
         allureReporter.addArgument('deviceType', capabilities.deviceType);

--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,8 @@ export default class Video extends WdioReporter {
     this.capabilities = runner.capabilities;
     this.isMultiremote = runner.isMultiremote || false;
 
-    const sessionId = runner.isMultiremote ?
-      Object.entries(runner.capabilities).map(([, capabilities]) => capabilities.sessionId)
+    const sessionId = runner.isMultiremote
+      ? Object.entries(runner.capabilities).map(([, capabilities]) => capabilities.sessionId)
       : runner.sessionId;
     this.sessionId = sessionId;
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,11 @@ export default class Video extends WdioReporter {
     this.frameNr = 0;
     this.videos = [];
     this.config = config;
+    this.isMultiremote = false;
+    this.capabilities = {};
+    this.sessionId;
+    this.runnerInstance;
+
 
     helpers.setLogger(msg => this.write(msg));
   }
@@ -63,20 +68,35 @@ export default class Video extends WdioReporter {
   /**
    * Set wdio config options
    */
-  onRunnerStart (browser) {
-    const allureConfig = browser.config.reporters.filter(r => r === 'allure' || r[0] === 'allure').pop();
+  onRunnerStart (runner) {
+    this.capabilities = runner.capabilities;
+    this.isMultiremote = runner.isMultiremote || false;
+
+    const sessionId = runner.isMultiremote ?
+      Object.entries(runner.capabilities).map(([, capabilities]) => capabilities.sessionId)
+      : runner.sessionId;
+    this.sessionId = sessionId;
+
+    const runnerInstance = runner.isMultiremote ?
+      runner.instanceOptions[sessionId[0]]
+    : runner.instanceOptions[sessionId];
+    this.runnerInstance = runnerInstance;
+
+    const allureConfig = runnerInstance.reporters.filter(r => r === 'allure' || r[0] === 'allure').pop();
+
     if (allureConfig && allureConfig[1] && allureConfig[1].outputDir) {
       config.allureOutputDir = path.resolve(allureConfig[1].outputDir);
     }
     config.usingAllure = !!allureConfig;
-    const logLevel = browser.config.logLevel;
+    const logLevel = runnerInstance.logLevel;
+
     config.debugMode = logLevel.toLowerCase() === 'trace' || logLevel.toLowerCase() === 'debug';
 
-    helpers.debugLog('Using reporter config:' + JSON.stringify(browser.config.reporters, undefined, 2) + '\n\n');
+    helpers.debugLog('Using reporter config:' + JSON.stringify(runnerInstance.reporters, undefined, 2) + '\n\n');
     helpers.debugLog('Using config:' + JSON.stringify(config, undefined, 2) + '\n\n\n');
 
     // Jasmine and Mocha ought to behave the same regarding test-structure
-    this.framework = browser.config.framework === 'cucumber' ? cucumberFramework : defaultFramework;
+    this.framework = runnerInstance.framework === 'cucumber' ? cucumberFramework : defaultFramework;
     this.framework.frameworkInit.call(this, browser);
 
     if(config.usingAllure) {
@@ -158,11 +178,16 @@ export default class Video extends WdioReporter {
     this.testnameStructure.pop();
 
     if(config.usingAllure) {
-      if (browser.capabilities.deviceType) {
-        allureReporter.addArgument('deviceType', browser.capabilities.deviceType);
+
+      const capabilities = this.isMultiremote
+      ? this.capabilities[Object.keys(this.capabilities)[0]]
+      : this.capabilities;
+
+      if (capabilities.deviceType) {
+        allureReporter.addArgument('deviceType', capabilities.deviceType);
       }
-      if (browser.capabilities.browserVersion) {
-        allureReporter.addArgument('browserVersion', browser.capabilities.browserVersion);
+      if (capabilities.browserVersion) {
+        allureReporter.addArgument('browserVersion', capabilities.browserVersion);
       }
     }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -373,23 +373,13 @@ describe('wdio-video-recorder - ', () => {
 
     describe('onRunnerStart - Multi remote ', () => {
       it('should user Allure default outputDir if not set in wdio config', () => {
-        console.log('**options***' + JSON.stringify(options));
-
         const video = new Video(options);
-
-        console.log('***browser**' + JSON.stringify(browser));
-
-
         video.onRunnerStart(global.multiBrowser);
-        console.log('*****' + JSON.stringify(video));
-        console.log('*****' + JSON.stringify(video.config));
         expect(video.config.allureOutputDir).toBe(allureDefaultOutputDir);
       });
 
       it('should use custom allure outputDir if set in config', () => {
-        // global.browser.config.reporters.push(['allure', {outputDir: 'customDir'}]);
         global.multiBrowser.instanceOptions.d7504eefa17d45ad7859fe4437e8643f.reporters.push(['allure', {outputDir: 'customDir'}]);
-
         let video = new Video(options);
         video.onRunnerStart(global.multiBrowser);
         expect(video.config.allureOutputDir).toBe('customDir');


### PR DESCRIPTION
This PR provide the fix for issue
https://github.com/webdriverio-community/wdio-video-reporter/issues/67

This has been tested for below use cases :
1. When wdio run in non multi remote mode
```
capabilities: [{
  browserName: 'chrome',
}],
```
2. When wdio run in multi remote mode with one browser (browser capability is given custom name)
```
capabilities: {
  Mybrowser1 : {
    capabilities: {
      browserName: 'chrome',
    },
  }
}
```
3. When wdio run in multi remote mode with two browser - Here we get video from one browser only. But tests do not stop and runs as they should. Now how to get two videos in one test that can be a future enhancement.
```
capabilities: {
  Mybrowser1 : {
    capabilities: {
      browserName: 'chrome',
    },
  },
  Mybrowser2 : {
    capabilities: {
      browserName: 'chrome',
    },
  }
}
```

Since this is my first contribution to open source repo, I might have missed something to add in PR description, so If there is any thing else needs to be added as part of PR description please let me know.
