### PR TITLE
fix logLevel not being parsed from wdio.conf

### DIFF
--- a/dist/wdio-video-reporter.js
+++ b/dist/wdio-video-reporter.js
@@ -472,6 +472,7 @@ class Video extends WdioReporter {
     config.jsonWireActions.push(...(options.addJsonWireActions || []));
     config.recordAllActions = options.recordAllActions || false;
     config.maxTestNameCharacters = options.maxTestNameCharacters || config.maxTestNameCharacters;
+    config.logLevel = options.logLevel || config.logLevel;
 
     this.screenshotPromises = [];
     this.videos = [];

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ export default class Video extends WdioReporter {
     config.jsonWireActions.push(...(options.addJsonWireActions || []));
     config.recordAllActions = options.recordAllActions || false;
     config.maxTestNameCharacters = options.maxTestNameCharacters || config.maxTestNameCharacters;
+    config.logLevel = options.logLevel || config.logLevel;
 
     this.screenshotPromises = [];
     this.videos = [];


### PR DESCRIPTION
The video reporter always defaults to logLevel from config.js.  
Basically logLevel is not being parsed from wdio.conf.  
This should fix it.
In relation to https://github.com/webdriverio-community/wdio-video-reporter/pull/77