### PR TITLE
chore(readme): redundant line and spelling corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ wdio-video-reporter [![Build Status](https://travis-ci.org/presidenten/wdio-vide
 
 ![Logo](https://raw.githubusercontent.com/presidenten/wdio-video-reporter-example-report/master/wdio-video-reporter.png)
 
-This is a reporter for [Webdriver IO v6 and highr](https://webdriver.io/) that generates videos of your wdio test executions. If you use allure, then the test cases automatically get decorated with the videos as well. (For Webdriver IO v5, please use wdio-video-reporter version ^2.0.0.)
+This is a reporter for [Webdriver IO v6 and higher](https://webdriver.io/) that generates videos of your wdio test executions. If you use allure, then the test cases automatically get decorated with the videos as well. (For Webdriver IO v5, please use wdio-video-reporter version ^2.0.0.)
 
 Videos ends up in `wdio.config.outputDir`
 
@@ -129,7 +129,6 @@ Most users may want to set these
 - `saveAllVideos` Set to true to save videos for passing tests. `Default: false`
 - `videoSlowdownMultiplier` Integer between [1-100]. Increase if videos are playing to quick. `Default: 3`
 - `videoRenderTimeout` Max seconds to wait for a video to render. `Default: 5`
-- `outputDir` If its not set, it uses wdio.config.outputDir. `Default: undefined`
 - `outputDir` If its not set, it uses wdio.config.outputDir. `Default: undefined`
 - `maxTestNameCharacters` Max length of test name. `Default: 250`
 


### PR DESCRIPTION
Redundant line removed from Readme file, and a spelling of a word corrected.