### PR TITLE
use async sleep (issue #66)

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,9 +8,8 @@ import config from './config.js';
 
 let writeLog;
 export default {
-  sleep(ms) {
-    const stop = new Date().getTime() + ms;
-    while(new Date().getTime() < stop);
+  async sleep(ms) {
+    await new Promise(resolve => setTimeout(resolve, ms));
   },
 
   setLogger(obj) {
@@ -97,12 +96,12 @@ export default {
     return promise;
   },
 
-  waitForVideosToExist(videos, abortTime) {
+  async waitForVideosToExist(videos, abortTime) {
     let allExist = false;
     let allGenerated = false;
 
     do {
-      this.sleep(100);
+      await this.sleep(100);
       allExist = videos
         .map(v => fs.existsSync(v))
         .reduce((acc, cur) => acc && cur, true);
@@ -114,12 +113,12 @@ export default {
     } while (new Date().getTime() < abortTime && !(allExist && allGenerated));
   },
 
-  waitForVideosToBeWritten(videos, abortTime) {
+  async waitForVideosToBeWritten(videos, abortTime) {
     let allSizes = [];
     let allConstant = false;
 
     do {
-      this.sleep(100);
+      await this.sleep(100);
       let currentSizes = videos.map(filename => ({filename, size: fs.statSync(filename).size}));
       allSizes = [...allSizes, currentSizes].slice(-3);
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ export default class Video extends WdioReporter {
   /**
    * Set wdio config options
    */
-  onRunnerStart (runner) {
+  async onRunnerStart (runner) {
     this.capabilities = runner.capabilities;
     this.isMultiremote = runner.isMultiremote || false;
 
@@ -102,7 +102,7 @@ export default class Video extends WdioReporter {
     this.framework.frameworkInit.call(this, browser);
 
     if(config.usingAllure) {
-      process.on('exit', () => this.onExit.call(this));
+      process.on('exit', async () => this.onExit.call(this));
     }
   }
 
@@ -243,11 +243,11 @@ export default class Video extends WdioReporter {
   /**
    * Finalize allure report
    */
-  onExit () {
+  async onExit () {
     const abortTime = new Date().getTime() + config.videoRenderTimeout*1000;
 
-    helpers.waitForVideosToExist(this.videos, abortTime);
-    helpers.waitForVideosToBeWritten(this.videos, abortTime);
+    await helpers.waitForVideosToExist(this.videos, abortTime);
+    await helpers.waitForVideosToBeWritten(this.videos, abortTime);
 
     if (new Date().getTime() > abortTime) {
       console.log(`videoRenderTimeout triggered, not all videos finished writing to disk before patching Allure`);

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -931,19 +931,19 @@ describe('wdio-video-recorder - ', () => {
       global.date = originalDate;
     });
 
-    it('should wait for videos to done', () => {
+    it('should wait for videos to done', async () => {
       let video = new Video(options);
       video.config.allureOutputDir = 'outputDir/allureDir';
       video.config.usingAllure = true;
       video.videos = videos;
 
-      video.onExit();
+      await video.onExit();
 
       expect(helpers.default.waitForVideosToExist).toHaveBeenCalled();
       expect(helpers.default.waitForVideosToBeWritten).toHaveBeenCalled();
     });
 
-    it('should print warning if videoRenderTimeout is triggered', () => {
+    it('should print warning if videoRenderTimeout is triggered', async () => {
       let video = new Video(options);
       video.config.allureOutputDir = 'outputDir/allureDir';
       video.config.usingAllure = true;
@@ -953,24 +953,24 @@ describe('wdio-video-recorder - ', () => {
         currentTime = configModule.default.videoRenderTimeout*1000 + 1;
       });
 
-      video.onExit();
+      await video.onExit();
 
       expect(global.console.log.mock.calls[0][0].includes('videoRenderTimeout triggered')).toBeTruthy();
     });
 
-    it('should update Allure report if Allure is present', () => {
+    it('should update Allure report if Allure is present', async () => {
       let video = new Video(options);
       video.config.allureOutputDir = 'outputDir/allureDir';
       video.config.usingAllure = true;
       video.videos = videos;
 
-      video.onExit();
+      await video.onExit();
 
       expect(fsMocks.copySync).toHaveBeenNthCalledWith(1, 'outputDir/MOCK-VIDEO-1.mp4', 'outputDir/allureDir/MOCK-ALLURE-1.mp4');
       expect(fsMocks.copySync).toHaveBeenNthCalledWith(2, 'outputDir/MOCK-VIDEO-2.mp4', 'outputDir/allureDir/MOCK-ALLURE-2.mp4');
     });
 
-    it('should not try to copy missing files to Allure', () => {
+    it('should not try to copy missing files to Allure', async () => {
       let video = new Video(options);
       video.config.allureOutputDir = 'outputDir/allureDir';
       video.config.usingAllure = true;
@@ -978,12 +978,12 @@ describe('wdio-video-recorder - ', () => {
 
       fsMocks.existsSync = jest.fn().mockReturnValue(false);
 
-      video.onExit();
+      await video.onExit();
 
       expect(fsMocks.copySync).not.toHaveBeenCalledWith('outputDir/MOCK-VIDEO-1.mp4', 'outputDir/allureDir/MOCK-ALLURE-1.mp4');
     });
 
-    it('should update Allure report if Allure is present with correct browser videos', () => {
+    it('should update Allure report if Allure is present with correct browser videos', async () => {
       const videos = ['outputDir/MOCK-VIDEO-1.mp4', 'outputDir/MOCK-VIDEO-2.mp4',
         'outputDir/MOCK-VIDEO-ANOTHER-BROWSER-1.mp4', 'outputDir/MOCK-VIDEO-ANOTHER-BROWSER-2.mp4'];
       let video = new Video(options);
@@ -991,7 +991,7 @@ describe('wdio-video-recorder - ', () => {
       video.config.usingAllure = true;
       video.videos = videos;
 
-      video.onExit();
+      await video.onExit();
 
       expect(fsMocks.copySync.mock.calls.length).toBe(2);
       expect(fsMocks.copySync).toHaveBeenNthCalledWith(1, 'outputDir/MOCK-VIDEO-1.mp4', 'outputDir/allureDir/MOCK-ALLURE-1.mp4');

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -870,6 +870,40 @@ describe('wdio-video-recorder - ', () => {
 
       expect(global.clearTimeout.mock.calls.length).toBe(1);
     });
+
+    it('should log video reporter actions if logLevel is not silent', async () => {
+      configModule.default.logLevel = 'info';
+      let video = new Video(options);
+      video.videos = videos;
+      video.write = jest.fn();
+
+      let resolve;
+      const videoDonePromise = new Promise((res) => { resolve = res; });
+      video.videoPromises.push(videoDonePromise);
+
+      video.onRunnerEnd();
+      resolve();
+      await flushPromises();
+
+      expect(video.write).toHaveBeenCalled();
+    });
+
+    it('should respect logLevel if it is silent', async () => {
+      configModule.default.logLevel = 'silent';
+      let video = new Video(options);
+      video.videos = videos;
+      video.write = jest.fn();
+
+      let resolve;
+      const videoDonePromise = new Promise((res) => { resolve = res; });
+      video.videoPromises.push(videoDonePromise);
+
+      video.onRunnerEnd();
+      resolve();
+      await flushPromises();
+
+      expect(video.write).not.toHaveBeenCalled();
+    });
   });
 
   describe('onExit - ', () => {


### PR DESCRIPTION
This addresses issue #66 by swapping the busy loop for an async/await timeout and amends/reinstates tests accordingly.

Additional test cases added to get branch coverage in index.js back to 100%