### PR TITLE
Bail early in onRunnerStart when no sessionId or runnerInstance is present

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,12 +77,19 @@ export default class Video extends WdioReporter {
     const sessionId = runner.isMultiremote
       ? Object.entries(runner.capabilities).map(([, capabilities]) => capabilities.sessionId)
       : runner.sessionId;
+
+    // May not be present in the case were a spawned worker has no tests when running a subset of the test suite.
+    if (!sessionId) return;
     this.sessionId = sessionId;
+
 
     const runnerInstance = runner.isMultiremote
       ? runner.instanceOptions[sessionId[0]]
       : runner.instanceOptions[sessionId];
+
+    if (!runnerInstance) return;
     this.runnerInstance = runnerInstance;
+
 
     const allureConfig = runnerInstance.reporters.filter(r => r === 'allure' || r[0] === 'allure').pop();
 

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,6 @@ export default class Video extends WdioReporter {
     if (!runnerInstance) return;
     this.runnerInstance = runnerInstance;
 
-
     const allureConfig = runnerInstance.reporters.filter(r => r === 'allure' || r[0] === 'allure').pop();
 
     if (allureConfig && allureConfig[1] && allureConfig[1].outputDir) {

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,6 @@ export default class Video extends WdioReporter {
     if (!sessionId) return;
     this.sessionId = sessionId;
 
-
     const runnerInstance = runner.isMultiremote
       ? runner.instanceOptions[sessionId[0]]
       : runner.instanceOptions[sessionId];

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -261,6 +261,21 @@ describe('wdio-video-recorder - ', () => {
     });
 
     describe('onRunnerStart - Non multi remote ', () => {
+      it('should bail early if there is no sessionId', () => {
+        const video = new Video(options);
+        video.onRunnerStart({...browser, sessionId: undefined });
+        expect(video.sessionId).toBe(undefined);
+        expect(video.runnerInstance).toBe(undefined);
+      });
+
+      it('should bail early if there is no found runnerInstance', () => {
+        const mockSessionId = 'not-in-instance-options';
+        const video = new Video(options);
+        video.onRunnerStart({...browser, sessionId: mockSessionId });
+        expect(video.sessionId).toBe(mockSessionId);
+        expect(video.runnerInstance).toBe(undefined);
+      });
+
       it('should user Allure default outputDir if not set in wdio config', () => {
         const video = new Video(options);
         video.onRunnerStart(browser);


### PR DESCRIPTION
For more info see this issue https://github.com/webdriverio/webdriverio/issues/9440. 

Wdio will still start a runner even if initialization failed due to the lack of tests when running only a subset of the test suite. This prevents an error from being thrown in this case

CC: @christian-bromann