### PR TITLE
Reinstate busy sleep (undoes "use async sleep (issue #66) (#86)")

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,14 +2,17 @@ import allureReporter from '@wdio/allure-reporter';
 import { path as ffmpegPath} from '@ffmpeg-installer/ffmpeg';
 import path from 'path';
 import fs from 'fs-extra';
+import { performance } from 'perf_hooks';
 import { spawn } from 'child_process';
 
 import config from './config.js';
 
 let writeLog;
+
 export default {
-  async sleep(ms) {
-    await new Promise(resolve => setTimeout(resolve, ms));
+  sleep(ms) {
+    const stop = performance.now() + ms;
+    while(performance.now() < stop);
   },
 
   setLogger(obj) {
@@ -96,12 +99,12 @@ export default {
     return promise;
   },
 
-  async waitForVideosToExist(videos, abortTime) {
+  waitForVideosToExist(videos, abortTime) {
     let allExist = false;
     let allGenerated = false;
 
     do {
-      await this.sleep(100);
+      this.sleep(100);
       allExist = videos
         .map(v => fs.existsSync(v))
         .reduce((acc, cur) => acc && cur, true);
@@ -113,12 +116,12 @@ export default {
     } while (new Date().getTime() < abortTime && !(allExist && allGenerated));
   },
 
-  async waitForVideosToBeWritten(videos, abortTime) {
+  waitForVideosToBeWritten(videos, abortTime) {
     let allSizes = [];
     let allConstant = false;
 
     do {
-      await this.sleep(100);
+      this.sleep(100);
       let currentSizes = videos.map(filename => ({filename, size: fs.statSync(filename).size}));
       allSizes = [...allSizes, currentSizes].slice(-3);
 

--- a/src/helpers.spec.js
+++ b/src/helpers.spec.js
@@ -47,15 +47,26 @@ describe('Helpers - ', () => {
   });
 
   describe('sleep - ', () => {
+    const realPerformanceNow = performance.now;
+
     beforeEach(() => {
       helpers.sleep = originalSleep;
+      performance.now = jest.fn()
+        .mockReturnValueOnce(2200)  // called once to configure the stop time
+        .mockReturnValueOnce(2200)  // then in a loop until ms has elapsed
+        .mockReturnValueOnce(2240)
+        .mockReturnValueOnce(2280)
+        .mockReturnValueOnce(2320)
+        .mockReturnValueOnce(2360)
+        .mockReturnValueOnce(2400);
     });
+    afterEach(() => {
+      performance.now = realPerformanceNow;
+    })
 
-    it('should sleep until requested time has passed', async () => {
-      const start = performance.now();
-      await helpers.sleep(100);
-      const end = performance.now();
-      expect(end - start).toBeGreaterThanOrEqual(100);
+    it('should sleep until requested time has passed', () => {
+      helpers.sleep(100);
+      expect(performance.now).toHaveBeenCalledTimes(5);
     });
   });
 
@@ -232,7 +243,7 @@ describe('Helpers - ', () => {
         .mockImplementationOnce(() => false)
         .mockImplementationOnce(() => false)
         .mockImplementation(() => true);
-      await helpers.waitForVideosToExist(videos, config.videoRenderTimeout*1000);
+      helpers.waitForVideosToExist(videos, config.videoRenderTimeout*1000);
       expect(helpers.sleep.mock.calls.length).toBe(3);
     });
 
@@ -245,7 +256,7 @@ describe('Helpers - ', () => {
         .mockImplementationOnce(() => ({ size: 48 }))
         .mockImplementationOnce(() => ({ size: 48 }))
         .mockImplementation(() => ({ size: 512 }));
-      await helpers.waitForVideosToExist(videos, config.videoRenderTimeout*1000);
+      helpers.waitForVideosToExist(videos, config.videoRenderTimeout*1000);
       expect(helpers.sleep.mock.calls.length).toBe(3);
     });
 
@@ -266,7 +277,7 @@ describe('Helpers - ', () => {
         .mockImplementationOnce(() => ({ size: 48 }))
         .mockImplementationOnce(() => ({ size: 48 }))
         .mockImplementation(() => ({ size: 512 }));
-      await helpers.waitForVideosToExist(videos, config.videoRenderTimeout*1000);
+      helpers.waitForVideosToExist(videos, config.videoRenderTimeout*1000);
       expect(helpers.sleep.mock.calls.length).toBe(5);
     });
 
@@ -290,7 +301,7 @@ describe('Helpers - ', () => {
         .mockImplementationOnce(() => ({ size: 48 }))
         .mockImplementationOnce(() => ({ size: 48 }))
         .mockImplementation(() => ({ size: 512 }));
-      await helpers.waitForVideosToExist(videos, config.videoRenderTimeout*1000);
+      helpers.waitForVideosToExist(videos, config.videoRenderTimeout*1000);
       expect(helpers.sleep.mock.calls.length).toBe(3);
     });
 
@@ -303,7 +314,7 @@ describe('Helpers - ', () => {
         .mockImplementationOnce(() => ({ size: 62 }))
         .mockImplementationOnce(() => ({ size: 73 }))
         .mockImplementation(() => ({ size: 512 }));
-      await helpers.waitForVideosToBeWritten(videos, config.videoRenderTimeout*1000);
+      helpers.waitForVideosToBeWritten(videos, config.videoRenderTimeout*1000);
       expect(helpers.sleep.mock.calls.length).toBe(2+3); // Two during reading and three good in a row
     });
 
@@ -319,7 +330,7 @@ describe('Helpers - ', () => {
         .mockImplementationOnce(() => ({ size: 62 }))
         .mockImplementationOnce(() => ({ size: 73 }))
         .mockImplementation(() => ({ size: 512 }));
-      await helpers.waitForVideosToBeWritten(videos, config.videoRenderTimeout*1000);
+      helpers.waitForVideosToBeWritten(videos, config.videoRenderTimeout*1000);
       expect(helpers.sleep.mock.calls.length).toBe(2);
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ export default class Video extends WdioReporter {
     this.framework.frameworkInit.call(this, browser);
 
     if(config.usingAllure) {
-      process.on('exit', async () => this.onExit.call(this));
+      process.on('exit', () => this.onExit.call(this));
     }
   }
 
@@ -251,8 +251,8 @@ export default class Video extends WdioReporter {
   async onExit () {
     const abortTime = new Date().getTime() + config.videoRenderTimeout*1000;
 
-    await helpers.waitForVideosToExist(this.videos, abortTime);
-    await helpers.waitForVideosToBeWritten(this.videos, abortTime);
+    helpers.waitForVideosToExist(this.videos, abortTime);
+    helpers.waitForVideosToBeWritten(this.videos, abortTime);
 
     if (new Date().getTime() > abortTime) {
       console.log(`videoRenderTimeout triggered, not all videos finished writing to disk before patching Allure`);

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -952,7 +952,7 @@ describe('wdio-video-recorder - ', () => {
       video.config.usingAllure = true;
       video.videos = videos;
 
-      await video.onExit();
+      video.onExit();
 
       expect(helpers.default.waitForVideosToExist).toHaveBeenCalled();
       expect(helpers.default.waitForVideosToBeWritten).toHaveBeenCalled();
@@ -963,12 +963,11 @@ describe('wdio-video-recorder - ', () => {
       video.config.allureOutputDir = 'outputDir/allureDir';
       video.config.usingAllure = true;
       video.videos = videos;
-
       helpers.default.waitForVideosToBeWritten = jest.fn().mockImplementation(() => {
         currentTime = configModule.default.videoRenderTimeout*1000 + 1;
       });
 
-      await video.onExit();
+      video.onExit();
 
       expect(global.console.log.mock.calls[0][0].includes('videoRenderTimeout triggered')).toBeTruthy();
     });
@@ -979,7 +978,7 @@ describe('wdio-video-recorder - ', () => {
       video.config.usingAllure = true;
       video.videos = videos;
 
-      await video.onExit();
+      video.onExit();
 
       expect(fsMocks.copySync).toHaveBeenNthCalledWith(1, 'outputDir/MOCK-VIDEO-1.mp4', 'outputDir/allureDir/MOCK-ALLURE-1.mp4');
       expect(fsMocks.copySync).toHaveBeenNthCalledWith(2, 'outputDir/MOCK-VIDEO-2.mp4', 'outputDir/allureDir/MOCK-ALLURE-2.mp4');
@@ -990,10 +989,9 @@ describe('wdio-video-recorder - ', () => {
       video.config.allureOutputDir = 'outputDir/allureDir';
       video.config.usingAllure = true;
       video.videos = [videos[0]];
-
       fsMocks.existsSync = jest.fn().mockReturnValue(false);
 
-      await video.onExit();
+      video.onExit();
 
       expect(fsMocks.copySync).not.toHaveBeenCalledWith('outputDir/MOCK-VIDEO-1.mp4', 'outputDir/allureDir/MOCK-ALLURE-1.mp4');
     });
@@ -1006,7 +1004,7 @@ describe('wdio-video-recorder - ', () => {
       video.config.usingAllure = true;
       video.videos = videos;
 
-      await video.onExit();
+      video.onExit();
 
       expect(fsMocks.copySync.mock.calls.length).toBe(2);
       expect(fsMocks.copySync).toHaveBeenNthCalledWith(1, 'outputDir/MOCK-VIDEO-1.mp4', 'outputDir/allureDir/MOCK-ALLURE-1.mp4');


### PR DESCRIPTION
Unfortunately, Node's process exit event handler requires a synchronous callback: https://nodejs.org/api/process.html#event-exit states "Listener functions must only perform synchronous operations."

So a busy wait is the only practical way of implementing a sleep. Fortunately, this is the only place where such a sleep happens (so it's done twice after all tests have completed). Without this, video files were no longer being resolved correctly for Allure reports. 

Removed async from the onExit code path and associated tests, and switched to performance.now instead of Date


