### PR TITLE
Implement `screenshotIntervalSecs` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Advanced users who want to change when the engine makes a screengrab can edit th
 - `addExcludedActions` Add actions where screenshots are unnecessary. `Default: []`
 - `addJsonWireActions` Add actions where screenshots are missing. `Default: []`
 - `recordAllActions` Skip filtering and screenshot everything. (Not recommended) `Default: false`
+- `screenshotIntervalSecs` Force a screenshot at this interval (minumum 0.5s) `Default: undefined`
 
 To see processed messages, set `wdio.config.logLevel: 'debug'` and check `outputDir/wdio-X-Y-Video-reporter.log`. This will also leave the screenshots output directory intact for review
 

--- a/src/config.js
+++ b/src/config.js
@@ -80,4 +80,6 @@ export default {
   // If test speed is not an issue, this option can be enabled to do a screenshot on every json wire message
   recordAllActions: false,
 
+  // Add a screenshot at a regular interval
+  screenshotIntervalSecs: undefined,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -54,7 +54,7 @@ export default {
     return filename;
   },
 
-  generateVideo() {
+  async generateVideo() {
     const videoPath = path.resolve(config.outputDir, this.testname + '.mp4');
     this.videos.push(videoPath);
 

--- a/src/helpers.spec.js
+++ b/src/helpers.spec.js
@@ -62,7 +62,7 @@ describe('Helpers - ', () => {
     });
     afterEach(() => {
       performance.now = realPerformanceNow;
-    })
+    });
 
     it('should sleep until requested time has passed', () => {
       helpers.sleep(100);

--- a/src/index.js
+++ b/src/index.js
@@ -237,7 +237,7 @@ export default class Video extends WdioReporter {
   /**
    * Finalize allure report
    */
-  async onExit () {
+  onExit () {
     const abortTime = new Date().getTime() + config.videoRenderTimeout*1000;
 
     helpers.waitForVideosToExist(this.videos, abortTime);

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,10 @@ export default class Video extends WdioReporter {
     config.recordAllActions = options.recordAllActions || false;
     config.maxTestNameCharacters = options.maxTestNameCharacters || config.maxTestNameCharacters;
     config.logLevel = options.logLevel || config.logLevel;
+    config.screenshotIntervalSecs = options.screenshotIntervalSecs || config.screenshotIntervalSecs;
+    if (config.screenshotIntervalSecs) {
+      config.screenshotIntervalSecs = Math.max(config.screenshotIntervalSecs, 0.5);
+    }
 
     this.screenshotPromises = [];
     this.videos = [];
@@ -54,7 +58,7 @@ export default class Video extends WdioReporter {
     this.capabilities = {};
     this.sessionId;
     this.runnerInstance;
-
+    this.intervalScreenshot = undefined;
 
     helpers.setLogger(msg => this.write(msg));
   }
@@ -126,26 +130,7 @@ export default class Video extends WdioReporter {
       return;
     }
 
-    const filename = this.frameNr.toString().padStart(4, '0') + '.png';
-    const filePath = path.resolve(this.recordingPath, filename);
-
-    // Create the report directory, if it does not exists
-    if (!fs.existsSync(this.recordingPath)) {
-      helpers.debugLog(`Creating: ${this.recordingPath}, as it not exists...\n`);
-      fs.mkdirsSync(this.recordingPath);
-    }
-
-    try {
-      this.screenshotPromises.push(
-        browser.saveScreenshot(filePath).then(() => {
-          helpers.debugLog('- Screenshot!!\n');
-        })
-      );
-    } catch (e) {
-      fs.writeFile(filePath, notAvailableImage, 'base64');
-      helpers.debugLog('- Screenshot not available...\n');
-    }
-    this.frameNr++;
+    this.addFrame();
   }
 
   /**
@@ -169,12 +154,22 @@ export default class Video extends WdioReporter {
    */
   onTestStart (test) {
     this.framework.onTestStart.call(this, test);
+
+    if (config.screenshotIntervalSecs) {
+      const instance = this;
+      this.intervalScreenshot = setInterval(() => instance.addFrame(), config.screenshotIntervalSecs * 1000);
+    }
   }
 
   /**
    * Remove empty directories
    */
   onTestSkip (test) {
+    if (this.intervalScreenshot) {
+      clearInterval(this.intervalScreenshot);
+      this.intervalScreenshot = undefined;
+    }
+
     this.framework.onTestSkip.call(this, test);
   }
 
@@ -182,6 +177,11 @@ export default class Video extends WdioReporter {
    * Add attachment to Allue if applicable and start to generate the video (Not applicable to Cucumber)
    */
   onTestEnd (test) {
+    if (this.intervalScreenshot) {
+      clearInterval(this.intervalScreenshot);
+      this.intervalScreenshot = undefined;
+    }
+
     this.testnameStructure.pop();
 
     if(config.usingAllure) {
@@ -197,18 +197,7 @@ export default class Video extends WdioReporter {
     }
 
     if (test.state === 'failed' || (test.state === 'passed' && config.saveAllVideos)) {
-      const filePath = path.resolve(this.recordingPath, this.frameNr.toString().padStart(4, '0') + '.png');
-      try {
-        this.screenshotPromises.push(
-          browser.saveScreenshot(filePath).then(() => {
-            helpers.debugLog('- Screenshot!!\n');
-          })
-        );
-      } catch (e) {
-        fs.writeFile(filePath, notAvailableImage, 'base64');
-        helpers.debugLog('- Screenshot not available...\n');
-      }
-
+      this.addFrame();
       helpers.generateVideo.call(this);
     }
   }
@@ -270,6 +259,28 @@ export default class Video extends WdioReporter {
           fs.copySync(videoFilePath, filePath);
         }
       });
+  }
+
+  addFrame () {
+    const frame = this.frameNr++;
+    const filePath = path.resolve(this.recordingPath, frame.toString().padStart(4, '0') + '.png');
+
+    // Create the report directory, if it does not exists
+    if (!fs.existsSync(this.recordingPath)) {
+      helpers.debugLog(`Creating: ${this.recordingPath}, as it not exists...\n`);
+      fs.mkdirsSync(this.recordingPath);
+    }
+
+    try {
+      this.screenshotPromises.push(
+        browser.saveScreenshot(filePath).then(() => {
+          helpers.debugLog(`- Screenshot!! (frame: ${frame})\n`);
+        })
+      );
+    } catch (e) {
+      fs.writeFile(filePath, notAvailableImage, 'base64');
+      helpers.debugLog('- Screenshot not available (frame: ${frame})...\n');
+    }
   }
 }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -358,6 +358,7 @@ describe('wdio-video-recorder - ', () => {
 
       it('should only register exit handler if using allure', () => {
         let video = new Video(options);
+        video.onExit = jest.fn();
         video.onRunnerStart(browser);
 
         expect(process.on).not.toHaveBeenCalled();
@@ -367,6 +368,11 @@ describe('wdio-video-recorder - ', () => {
         video.onRunnerStart(browser);
 
         expect(process.on).toHaveBeenCalled();
+        const callback = process.on.mock.calls[0][1];
+        jest.spyOn(video, 'onExit');
+        expect(video.onExit).not.toHaveBeenCalled();
+        callback(video);
+        expect(video.onExit).toHaveBeenCalled();
       });
 
       it('should figure out if multi remote is not being used', () => {
@@ -611,7 +617,7 @@ describe('wdio-video-recorder - ', () => {
         expect(browser.saveScreenshot).toHaveBeenCalledWith('folder/0000.png');
         expect(helpers.default.debugLog).toHaveBeenCalledWith('Incoming command: /session/abcdef/url => [url]\n');
         setImmediate(() => {
-          expect(helpers.default.debugLog).toHaveBeenCalledWith('- Screenshot!!\n');
+          expect(helpers.default.debugLog).toHaveBeenCalledWith('- Screenshot!! (frame: 0)\n');
           done();
         });
       });
@@ -676,6 +682,9 @@ describe('wdio-video-recorder - ', () => {
   });
 
   describe('onTestStart - ', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
     it('should call frameworks onTestStart', () => {
       let video = new Video(options);
       video.framework = {
@@ -683,6 +692,61 @@ describe('wdio-video-recorder - ', () => {
       };
       video.onTestStart({title: 'TEST'});
       expect(video.framework.onTestStart).toHaveBeenCalled();
+    });
+
+    it('should not initiate interval screenshots if not configured to do so', () => {
+      global.setInterval = jest.fn();
+
+      let video = new Video(options);
+      video.framework = {
+        onTestStart: jest.fn(),
+      };
+      video.onTestStart({title: 'TEST'});
+      expect(global.setInterval).not.toHaveBeenCalled();
+    });
+
+    it('should initiate interval screenshots if configured to do so', () => {
+      configModule.default.screenshotIntervalSecs = 2.5;
+      global.setInterval = jest.fn();
+      let video = new Video(options);
+      video.intervalScreenshot = undefined;
+      video.framework = {
+        onTestStart: jest.fn(),
+      };
+      video.onTestStart({title: 'TEST'});
+      expect(global.setInterval).toHaveBeenCalledWith(expect.any(Function), 2500);
+    });
+
+    it('should enforce a minimum 0.5 second screenshot interval', () => {
+      configModule.default.screenshotIntervalSecs = 0.1;
+      global.setInterval = jest.fn();
+
+      let video = new Video(options);
+      video.intervalScreenshot = undefined;
+      video.framework = {
+        onTestStart: jest.fn(),
+      };
+      video.onTestStart({title: 'TEST'});
+      expect(global.setInterval).toHaveBeenCalledWith(expect.any(Function), 500);
+    });
+
+    it('should take screenshots at regular intervals if configured to do so', () => {
+      configModule.default.screenshotIntervalSecs = 3;
+      global.setInterval = jest.fn();
+      let video = new Video(options);
+      video.intervalScreenshot = undefined;
+      video.framework = {
+        onTestStart: jest.fn(),
+      };
+      jest.useFakeTimers();
+      jest.spyOn(video, 'addFrame');
+      expect(video.addFrame).not.toHaveBeenCalled();
+      video.onTestStart({title: 'TEST'});
+      expect(video.addFrame).not.toHaveBeenCalled();
+      jest.runOnlyPendingTimers();
+      expect(video.addFrame).toHaveBeenCalledTimes(1);
+      jest.runOnlyPendingTimers();
+      expect(video.addFrame).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -694,6 +758,18 @@ describe('wdio-video-recorder - ', () => {
       };
       video.onTestSkip({title: 'TEST'});
       expect(video.framework.onTestSkip).toHaveBeenCalled();
+    });
+
+    it('should stop interval screenshots if running', () => {
+      global.clearInterval = jest.fn();
+      const interval = jest.fn();
+      let video = new Video(options);
+      video.intervalScreenshot = interval;
+      video.framework = {
+        onTestSkip: jest.fn(),
+      };
+      video.onTestSkip({title: 'TEST'});
+      expect(global.clearInterval).toHaveBeenCalledWith(interval);
     });
   });
 
@@ -770,7 +846,7 @@ describe('wdio-video-recorder - ', () => {
       video.onTestEnd({title: 'TEST', state: 'failed'});
       expect(browser.saveScreenshot).toHaveBeenCalledWith('folder/0000.png');
       setImmediate(() => {
-        expect(helpers.default.debugLog).toHaveBeenCalledWith('- Screenshot!!\n');
+        expect(helpers.default.debugLog).toHaveBeenCalledWith('- Screenshot!! (frame: 0)\n');
         done();
       });
     });
@@ -816,6 +892,18 @@ describe('wdio-video-recorder - ', () => {
       video.recordingPath = 'folder';
       video.onTestEnd({title: 'TEST', state: 'passed'});
       expect(helpers.default.generateVideo).toHaveBeenCalled();
+    });
+
+    it('should stop interval screenshots if running', () => {
+      global.clearInterval = jest.fn();
+      const interval = jest.fn();
+      let video = new Video(options);
+      video.intervalScreenshot = interval;
+      video.framework = {
+        onTestEnd: jest.fn(),
+      };
+      video.onTestEnd({title: 'TEST'});
+      expect(global.clearInterval).toHaveBeenCalledWith(interval);
     });
   });
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1034,7 +1034,7 @@ describe('wdio-video-recorder - ', () => {
       global.date = originalDate;
     });
 
-    it('should wait for videos to done', async () => {
+    it('should wait for videos to done when called synchronously', () => {
       let video = new Video(options);
       video.config.allureOutputDir = 'outputDir/allureDir';
       video.config.usingAllure = true;
@@ -1046,7 +1046,7 @@ describe('wdio-video-recorder - ', () => {
       expect(helpers.default.waitForVideosToBeWritten).toHaveBeenCalled();
     });
 
-    it('should print warning if videoRenderTimeout is triggered', async () => {
+    it('should print warning if videoRenderTimeout is triggered', () => {
       let video = new Video(options);
       video.config.allureOutputDir = 'outputDir/allureDir';
       video.config.usingAllure = true;
@@ -1060,7 +1060,7 @@ describe('wdio-video-recorder - ', () => {
       expect(global.console.log.mock.calls[0][0].includes('videoRenderTimeout triggered')).toBeTruthy();
     });
 
-    it('should update Allure report if Allure is present', async () => {
+    it('should update Allure report if Allure is present', () => {
       let video = new Video(options);
       video.config.allureOutputDir = 'outputDir/allureDir';
       video.config.usingAllure = true;
@@ -1072,7 +1072,7 @@ describe('wdio-video-recorder - ', () => {
       expect(fsMocks.copySync).toHaveBeenNthCalledWith(2, 'outputDir/MOCK-VIDEO-2.mp4', 'outputDir/allureDir/MOCK-ALLURE-2.mp4');
     });
 
-    it('should not try to copy missing files to Allure', async () => {
+    it('should not try to copy missing files to Allure', () => {
       let video = new Video(options);
       video.config.allureOutputDir = 'outputDir/allureDir';
       video.config.usingAllure = true;
@@ -1084,7 +1084,7 @@ describe('wdio-video-recorder - ', () => {
       expect(fsMocks.copySync).not.toHaveBeenCalledWith('outputDir/MOCK-VIDEO-1.mp4', 'outputDir/allureDir/MOCK-ALLURE-1.mp4');
     });
 
-    it('should update Allure report if Allure is present with correct browser videos', async () => {
+    it('should update Allure report if Allure is present with correct browser videos', () => {
       const videos = ['outputDir/MOCK-VIDEO-1.mp4', 'outputDir/MOCK-VIDEO-2.mp4',
         'outputDir/MOCK-VIDEO-ANOTHER-BROWSER-1.mp4', 'outputDir/MOCK-VIDEO-ANOTHER-BROWSER-2.mp4'];
       let video = new Video(options);


### PR DESCRIPTION
Proposal for Issue https://github.com/webdriverio-community/wdio-video-reporter/issues/90

Add a `screenshotIntervalSecs` configuration option.

Setting this will cause screenshots to be requested at regular intervals to enhance UI capturing.

Also, consolidate duplicated code to capture a frame into a single function and add debugging and tests

