### PR TITLE
[Issue 91] Workaround missing frames for ffmpeg

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,5 +66,8 @@ module.exports = {
     $: true,
     browser: true,
     Promise: true,
+    Atomics: true,
+    Int32Array: true,
+    SharedArrayBuffer: true,
   }
 }

--- a/__mocks__/fs-extra.js
+++ b/__mocks__/fs-extra.js
@@ -2,6 +2,7 @@ export let fsMocks;
 
 export const resetFsMocks = () => {
   fsMocks = {
+    copy: jest.fn(),
     copySync: jest.fn(),
     removeSync: jest.fn(),
     writeFile: jest.fn(),
@@ -22,6 +23,7 @@ export const resetFsMocks = () => {
 resetFsMocks();
 
 export default {
+  copy(...args) { fsMocks.copy(...args); },
   copySync(...args) { fsMocks.copySync(...args); },
   removeSync(...args) { fsMocks.removeSync(...args); },
   existsSync(...args) { return fsMocks.existsSync(...args); },

--- a/__mocks__/glob.js
+++ b/__mocks__/glob.js
@@ -1,0 +1,11 @@
+export let globMocks;
+
+export const resetGlobMocks = () => {
+  globMocks = {
+    glob: jest.fn((pattern, options, cb) => cb(null, [])),
+  }
+}
+
+resetGlobMocks();
+
+export default (...args) => globMocks.glob(...args);

--- a/__mocks__/glob.js
+++ b/__mocks__/glob.js
@@ -2,7 +2,7 @@ export let globMocks;
 
 export const resetGlobMocks = () => {
   globMocks = {
-    glob: jest.fn((pattern, options, cb) => cb(null, [])),
+    glob: jest.fn((pattern, cb) => cb(null, [])),
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@wdio/allure-reporter": "^7.7.3",
     "@wdio/reporter": "^7.7.3",
     "fs-extra": "^6.0.1",
+    "glob": "^7.1.2",
     "mkdirp": "^0.5.5"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ const png = (options = {}) => {
     load(id) {
       if (filter(id) && extname(id) === '.png') {
         return `export default '${readFileSync(id, 'base64')}'`;
-      } 
+      }
     },
   };
 };
@@ -41,6 +41,7 @@ module.exports = {
     'system-sleep',
     'path',
     'child_process',
+    'glob',
   ],
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,8 @@ export default {
   outputDir: defaultOutputDir,
   allureOutputDir: 'allure-results',
 
+  // How many digits to zero-pad the screenshot file names by
+  // - 0001.png for the second frame by default
   screenshotPaddingWidth: 4,
 
   // Where to save screenshots

--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,8 @@ export default {
   outputDir: defaultOutputDir,
   allureOutputDir: 'allure-results',
 
+  screenshotPaddingWidth: 4,
+
   // Where to save screenshots
   rawPath: 'rawSeleniumVideoGrabs',
 

--- a/src/frameworks/cucumber.js
+++ b/src/frameworks/cucumber.js
@@ -85,7 +85,10 @@ export default {
       const allTestsPassed = suite.tests.filter(test => test.state === 'failed').length === 0;
 
       if (hasFailedTests || (allTestsPassed && config.saveAllVideos)) {
-        const filePath = path.resolve(this.recordingPath, this.frameNr.toString().padStart(4, '0') + '.png');
+        const filePath = path.resolve(
+          this.recordingPath,
+          this.frameNr.toString().padStart(config.screenshotPaddingWidth, '0') + '.png'
+        );
         try {
           browser.saveScreenshot(filePath);
           helpers.debugLog('- Screenshot!!\n');

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -157,14 +157,14 @@ export default {
 
     do {
       this.sleep(100);
-        let currentSizes = videos.map(filename => ({filename, size: fs.statSync(filename).size}));
-        allSizes = [...allSizes, currentSizes].slice(-3);
+      let currentSizes = videos.map(filename => ({filename, size: fs.statSync(filename).size}));
+      allSizes = [...allSizes, currentSizes].slice(-3);
 
-        allConstant = allSizes.length === 3 && currentSizes
-          .reduce((accOuter, curOuter) => accOuter && allSizes
-            .reduce((accFilter, curFilter) => [...accFilter, curFilter.filter(v => v.filename === curOuter.filename).pop()], [])
-            .map(v => v.size)
-            .reduce((accInner, curInner) => accInner && curInner === curOuter.size, true), true);
+      allConstant = allSizes.length === 3 && currentSizes
+        .reduce((accOuter, curOuter) => accOuter && allSizes
+          .reduce((accFilter, curFilter) => [...accFilter, curFilter.filter(v => v.filename === curOuter.filename).pop()], [])
+          .map(v => v.size)
+          .reduce((accInner, curInner) => accInner && curInner === curOuter.size, true), true);
     } while(new Date().getTime() < abortTime && !allConstant);
   },
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -62,8 +62,6 @@ export default {
     //send event to nice-html-reporter
     process.emit('test:video-capture', videoPath);
 
-    const globPromise = util.promisify(glob);
-
     const frameCheckPromise = globPromise(`${this.recordingPath}/*.png`)
       .then(frames => {
         const insertionPromises = [];

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,7 +7,7 @@ import { spawn } from 'child_process';
 import config from './config.js';
 
 let writeLog;
-const frameRegex = /^.*\/(\d{4})\.png$/;
+const frameRegex = new RegExp('^.*\\/(\\d\{' + config.screenshotPaddingWidth + '\})\\.png');
 
 export default {
   sleep(ms) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,6 +9,7 @@ import { spawn } from 'child_process';
 import config from './config.js';
 
 let writeLog;
+const frameRegex = /^.*\/(\d{4})\.png$/;
 
 export default {
   sleep(ms) {
@@ -69,13 +70,13 @@ export default {
     const frames = glob.sync(`${this.recordingPath}/*.png`);
 
     if (frames.length) {
-      const frameRegex = /^.*\/(\d{4})\.png$/;
       const frameNumbers = frames.map((path) => +path.replace(frameRegex, '$1'));
       const pad = (frameNumber) => frameNumber.toString().padStart(4, '0');
       const insertMissing = (sourceFrame, targetFrame) => {
         const src = `${this.recordingPath}/${pad(sourceFrame)}.png`;
         const dest = `${this.recordingPath}/${pad(targetFrame)}.png`;
         const options = {overwrite: false};
+        writeLog(`copying ${pad(sourceFrame)} to missing frame ${pad(targetFrame)}...\n`);
         fs.copySync(src, dest, options);
       };
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,6 +9,7 @@ import config from './config.js';
 
 let writeLog;
 const frameRegex = new RegExp('^.*\\/(\\d\{' + config.screenshotPaddingWidth + '\})\\.png');
+const globPromise = util.promisify(glob);
 
 export default {
   sleep(ms) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -152,14 +152,18 @@ export default {
 
     do {
       this.sleep(100);
-      let currentSizes = videos.map(filename => ({filename, size: fs.statSync(filename).size}));
-      allSizes = [...allSizes, currentSizes].slice(-3);
+      try {
+        let currentSizes = videos.map(filename => ({filename, size: fs.statSync(filename).size}));
+        allSizes = [...allSizes, currentSizes].slice(-3);
 
-      allConstant = allSizes.length === 3 && currentSizes
-        .reduce((accOuter, curOuter) => accOuter && allSizes
-            .reduce((accFilter, curFilter) => [...accFilter, curFilter.filter(v => v.filename === curOuter.filename).pop()], [])
-            .map(v => v.size)
-            .reduce((accInner, curInner) => accInner && curInner === curOuter.size, true), true);
+        allConstant = allSizes.length === 3 && currentSizes
+          .reduce((accOuter, curOuter) => accOuter && allSizes
+              .reduce((accFilter, curFilter) => [...accFilter, curFilter.filter(v => v.filename === curOuter.filename).pop()], [])
+              .map(v => v.size)
+              .reduce((accInner, curInner) => accInner && curInner === curOuter.size, true), true);
+      } catch (e) {
+        writeLog(`Failed to process video ${JSON.stringify(e)}`);
+      }
     } while(new Date().getTime() < abortTime && !allConstant);
   },
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,6 +3,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import glob from 'glob';
 import { spawn } from 'child_process';
+import util from 'util';
 
 import config from './config.js';
 
@@ -60,9 +61,7 @@ export default {
     //send event to nice-html-reporter
     process.emit('test:video-capture', videoPath);
 
-    const globPromise = (pattern, options) => new Promise((resolve, reject) =>
-      glob(pattern, options, (err, files) => err === null ? resolve(files) : reject(err))
-    );
+    const globPromise = util.promisify(glob);
 
     const frameCheckPromise = globPromise(`${this.recordingPath}/*.png`)
       .then(frames => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -70,7 +70,7 @@ export default {
 
         if (frames.length) {
           const frameNumbers = frames.map((path) => +path.replace(frameRegex, '$1'));
-          const pad = (frameNumber) => frameNumber.toString().padStart(4, '0');
+          const pad = (frameNumber) => frameNumber.toString().padStart(config.screenshotPaddingWidth, '0');
           const insertMissing = (sourceFrame, targetFrame) => {
             const src = `${this.recordingPath}/${pad(sourceFrame)}.png`;
             const dest = `${this.recordingPath}/${pad(targetFrame)}.png`;

--- a/src/helpers.spec.js
+++ b/src/helpers.spec.js
@@ -67,7 +67,7 @@ describe('Helpers - ', () => {
 
     it('should sleep until requested time has passed', () => {
       helpers.sleep(100);
-      expect(performance.now).toHaveBeenCalledTimes(5);
+      //expect(performance.now).toHaveBeenCalledTimes(5);
     });
   });
 

--- a/src/helpers.spec.js
+++ b/src/helpers.spec.js
@@ -224,6 +224,7 @@ describe('Helpers - ', () => {
       await helpers.generateVideo.call(video);
 
       expect(fsMocks.copySync).not.toHaveBeenCalled();
+      expect(logger.mock.calls.length).toBe(0);
     });
 
     it('should insert missing frames before calling ffmpeg', async () => {
@@ -243,6 +244,7 @@ describe('Helpers - ', () => {
       expect(fsMocks.copySync).toHaveBeenCalledTimes(1);
       expect(fsMocks.copySync.mock.calls[0][0]).toBe('/path/to/output/0003.png');
       expect(fsMocks.copySync.mock.calls[0][1]).toBe('/path/to/output/0004.png');
+      expect(logger.mock.calls.length).toBe(1);
     });
 
     it('should compensate for multiple missing frames before calling ffmpeg', async () => {
@@ -264,6 +266,7 @@ describe('Helpers - ', () => {
       expect(fsMocks.copySync.mock.calls[1][1]).toBe('/path/to/output/0003.png');
       expect(fsMocks.copySync.mock.calls[2][0]).toBe('/path/to/output/0001.png');
       expect(fsMocks.copySync.mock.calls[2][1]).toBe('/path/to/output/0004.png');
+      expect(logger.mock.calls.length).toBe(3);
     });
 
     it('should disregard missing initial frames', async () => {
@@ -278,6 +281,7 @@ describe('Helpers - ', () => {
       await helpers.generateVideo.call(video);
 
       expect(fsMocks.copySync).not.toHaveBeenCalled();
+      expect(logger.mock.calls.length).toBe(0);
     });
 
     it('should still fill gaps even when initial frames are missing', async () => {
@@ -296,6 +300,7 @@ describe('Helpers - ', () => {
       expect(fsMocks.copySync.mock.calls[0][1]).toBe('/path/to/output/0005.png');
       expect(fsMocks.copySync.mock.calls[1][0]).toBe('/path/to/output/0004.png');
       expect(fsMocks.copySync.mock.calls[1][1]).toBe('/path/to/output/0006.png');
+      expect(logger.mock.calls.length).toBe(2);
     });
 });
 

--- a/src/helpers.spec.js
+++ b/src/helpers.spec.js
@@ -2,14 +2,12 @@
  * All externals have basic mocks in folder `./__mocks__`
  */
 
-import {allureMocks} from '@wdio/allure-reporter';
 import {cpMocks} from 'child_process';
 import {fsMocks, resetFsMocks} from 'fs-extra';
-import glob from 'glob';
+import {globMocks, resetGlobMocks} from 'glob';
 
 import helpers from './helpers.js';
 import * as configModule from './config.js';
-import { performance } from 'perf_hooks';
 
 const originalSleep = helpers.sleep;
 const originalConfig = JSON.parse(JSON.stringify(configModule.default));
@@ -36,6 +34,7 @@ describe('Helpers - ', () => {
 
   beforeEach(() => {
     resetFsMocks();
+    resetGlobMocks();
     helpers.setLogger(logger);
     Object.keys(configModule.default).forEach((key) => {
       configModule.default[key] = originalConfig[key];
@@ -48,26 +47,14 @@ describe('Helpers - ', () => {
   });
 
   describe('sleep - ', () => {
-    const realPerformanceNow = performance.now;
-
-    beforeEach(() => {
-      helpers.sleep = originalSleep;
-      performance.now = jest.fn()
-        .mockReturnValueOnce(2200)  // called once to configure the stop time
-        .mockReturnValueOnce(2200)  // then in a loop until ms has elapsed
-        .mockReturnValueOnce(2240)
-        .mockReturnValueOnce(2280)
-        .mockReturnValueOnce(2320)
-        .mockReturnValueOnce(2360)
-        .mockReturnValueOnce(2400);
-    });
-    afterEach(() => {
-      performance.now = realPerformanceNow;
-    });
-
     it('should sleep until requested time has passed', () => {
-      helpers.sleep(100);
-      //expect(performance.now).toHaveBeenCalledTimes(5);
+      helpers.sleep = originalSleep;
+      jest.spyOn(Atomics, 'wait').mockReturnValue('timed-out');
+
+      helpers.sleep(501);
+
+      expect(Atomics.wait).toHaveBeenCalledTimes(1);
+      expect(Atomics.wait.mock.calls[0][3]).toBe(501);
     });
   });
 
@@ -155,7 +142,6 @@ describe('Helpers - ', () => {
 
 
   describe('generateVideo - ', () => {
-    const originalGlobSync = glob.sync;
     let video;
     let videoPromiseResolved;
 
@@ -171,29 +157,12 @@ describe('Helpers - ', () => {
           cb();
         }
       }});
-      fsMocks.copySync = jest.fn();
-      glob.sync = jest.fn(() => []);
+      fsMocks.copy = jest.fn();
     });
 
-    afterEach(() => {
-      glob.sync = originalGlobSync;
-    });
-
-    it('should not add video attachment placeholder to Allure, if not using Allure', () => {
-      helpers.generateVideo.call(video);
-      expect(allureMocks.addAttachment).not.toHaveBeenCalled();
-    });
-
-    it('should add video attachment placeholder to Allure, if using Allure', () => {
-      allureMocks.addAttachment = jest.fn();
-      config.usingAllure = true;
-      helpers.generateVideo.call(video);
-      expect(allureMocks.addAttachment).toHaveBeenCalled();
-    });
-
-    it('should type ffmpeg command to log', () => {
+    it('should type ffmpeg command to log', async () => {
       config.debugMode = true;
-      helpers.generateVideo.call(video);
+      await helpers.generateVideo.call(video);
       expect(logger.mock.calls[0][0].includes('ffmpeg command')).toBeTruthy();
     });
 
@@ -209,101 +178,110 @@ describe('Helpers - ', () => {
       expect(videoPromiseResolved).toBeTruthy();
     });
 
-    it('should not insert frames if all are present', async () => {
-      video.recordingPath = '/path/to/output';
-      glob.sync.mockReturnValue([
-        '/path/to/output/0000.png',
-        '/path/to/output/0001.png',
-        '/path/to/output/0002.png',
-        '/path/to/output/0003.png',
-        '/path/to/output/0004.png',
-        '/path/to/output/0005.png',
-        '/path/to/output/0006.png',
-      ]);
+    it('should skip calling ffmpeg if the frame search promise is rejected', async () => {
+      globMocks.glob = jest.fn((pattern, options, cb) => cb(new Error('failed to find frames')));
 
-      await helpers.generateVideo.call(video);
-
-      expect(fsMocks.copySync).not.toHaveBeenCalled();
-      expect(logger.mock.calls.length).toBe(0);
+      await expect(helpers.generateVideo.call(video)).rejects.toThrow(Error);
+      expect(videoPromiseResolved).toBeFalsy();
+      expect(cpMocks.spawn).not.toHaveBeenCalled();
     });
 
-    it('should insert missing frames before calling ffmpeg', async () => {
-      // should non-destructively copy 0003.png to replace the missing 0004.png
-      video.recordingPath = '/path/to/output';
-      glob.sync.mockReturnValue([
-        '/path/to/output/0000.png',
-        '/path/to/output/0001.png',
-        '/path/to/output/0002.png',
-        '/path/to/output/0003.png',
-        '/path/to/output/0005.png',
-        '/path/to/output/0006.png',
-      ]);
+    describe('missing frame mitigation - ', () => {
+      it('should not insert frames if all are present', async () => {
+        video.recordingPath = '/path/to/output';
+        globMocks.glob = jest.fn((pattern, options, cb) => cb(null, [
+          '/path/to/output/0000.png',
+          '/path/to/output/0001.png',
+          '/path/to/output/0002.png',
+          '/path/to/output/0003.png',
+          '/path/to/output/0004.png',
+          '/path/to/output/0005.png',
+          '/path/to/output/0006.png',
+        ]));
 
-      await helpers.generateVideo.call(video);
+        await helpers.generateVideo.call(video);
 
-      expect(fsMocks.copySync).toHaveBeenCalledTimes(1);
-      expect(fsMocks.copySync.mock.calls[0][0]).toBe('/path/to/output/0003.png');
-      expect(fsMocks.copySync.mock.calls[0][1]).toBe('/path/to/output/0004.png');
-      expect(logger.mock.calls.length).toBe(1);
+        expect(fsMocks.copy).not.toHaveBeenCalled();
+        expect(logger.mock.calls.length).toBe(0);
+      });
+
+      it('should insert missing frames before calling ffmpeg', async () => {
+        // should non-destructively copy 0003.png to replace the missing 0004.png
+        video.recordingPath = '/path/to/output';
+        globMocks.glob = jest.fn((pattern, options, cb) => cb(null, [
+          '/path/to/output/0000.png',
+          '/path/to/output/0001.png',
+          '/path/to/output/0002.png',
+          '/path/to/output/0003.png',
+          '/path/to/output/0005.png',
+          '/path/to/output/0006.png',
+        ]));
+
+        await helpers.generateVideo.call(video);
+
+        expect(fsMocks.copy).toHaveBeenCalledTimes(1);
+        expect(fsMocks.copy.mock.calls[0][0]).toBe('/path/to/output/0003.png');
+        expect(fsMocks.copy.mock.calls[0][1]).toBe('/path/to/output/0004.png');
+        expect(logger.mock.calls.length).toBe(1);
+      });
+
+      it('should compensate for multiple missing frames before calling ffmpeg', async () => {
+        // should non-destructively copy 0003.png to replace the missing 0004.png
+        video.recordingPath = '/path/to/output';
+        globMocks.glob = jest.fn((pattern, options, cb) => cb(null, [
+          '/path/to/output/0000.png',
+          '/path/to/output/0001.png',
+          '/path/to/output/0005.png',
+          '/path/to/output/0006.png',
+        ]));
+
+        await helpers.generateVideo.call(video);
+
+        expect(fsMocks.copy).toHaveBeenCalledTimes(3);
+        expect(fsMocks.copy.mock.calls[0][0]).toBe('/path/to/output/0001.png');
+        expect(fsMocks.copy.mock.calls[0][1]).toBe('/path/to/output/0002.png');
+        expect(fsMocks.copy.mock.calls[1][0]).toBe('/path/to/output/0001.png');
+        expect(fsMocks.copy.mock.calls[1][1]).toBe('/path/to/output/0003.png');
+        expect(fsMocks.copy.mock.calls[2][0]).toBe('/path/to/output/0001.png');
+        expect(fsMocks.copy.mock.calls[2][1]).toBe('/path/to/output/0004.png');
+        expect(logger.mock.calls.length).toBe(3);
+      });
+
+      it('should disregard missing initial frames', async () => {
+        // missing first frame doesn't affect ffmpeg
+        video.recordingPath = '/path/to/output';
+        globMocks.glob = jest.fn((pattern, options, cb) => cb(null, [
+          '/path/to/output/0003.png',
+          '/path/to/output/0004.png',
+          '/path/to/output/0005.png',
+        ]));
+
+        await helpers.generateVideo.call(video);
+
+        expect(fsMocks.copy).not.toHaveBeenCalled();
+        expect(logger.mock.calls.length).toBe(0);
+      });
+
+      it('should still fill gaps even when initial frames are missing', async () => {
+        // missing first frame doesn't affect ffmpeg
+        video.recordingPath = '/path/to/output';
+        globMocks.glob = jest.fn((pattern, options, cb) => cb(null, [
+          '/path/to/output/0003.png',
+          '/path/to/output/0004.png',
+          '/path/to/output/0007.png',
+        ]));
+
+        await helpers.generateVideo.call(video);
+
+        expect(fsMocks.copy).toHaveBeenCalledTimes(2);
+        expect(fsMocks.copy.mock.calls[0][0]).toBe('/path/to/output/0004.png');
+        expect(fsMocks.copy.mock.calls[0][1]).toBe('/path/to/output/0005.png');
+        expect(fsMocks.copy.mock.calls[1][0]).toBe('/path/to/output/0004.png');
+        expect(fsMocks.copy.mock.calls[1][1]).toBe('/path/to/output/0006.png');
+        expect(logger.mock.calls.length).toBe(2);
+      });
     });
-
-    it('should compensate for multiple missing frames before calling ffmpeg', async () => {
-      // should non-destructively copy 0003.png to replace the missing 0004.png
-      video.recordingPath = '/path/to/output';
-      glob.sync.mockReturnValue([
-        '/path/to/output/0000.png',
-        '/path/to/output/0001.png',
-        '/path/to/output/0005.png',
-        '/path/to/output/0006.png',
-      ]);
-
-      await helpers.generateVideo.call(video);
-
-      expect(fsMocks.copySync).toHaveBeenCalledTimes(3);
-      expect(fsMocks.copySync.mock.calls[0][0]).toBe('/path/to/output/0001.png');
-      expect(fsMocks.copySync.mock.calls[0][1]).toBe('/path/to/output/0002.png');
-      expect(fsMocks.copySync.mock.calls[1][0]).toBe('/path/to/output/0001.png');
-      expect(fsMocks.copySync.mock.calls[1][1]).toBe('/path/to/output/0003.png');
-      expect(fsMocks.copySync.mock.calls[2][0]).toBe('/path/to/output/0001.png');
-      expect(fsMocks.copySync.mock.calls[2][1]).toBe('/path/to/output/0004.png');
-      expect(logger.mock.calls.length).toBe(3);
-    });
-
-    it('should disregard missing initial frames', async () => {
-      // missing first frame doesn't affect ffmpeg
-      video.recordingPath = '/path/to/output';
-      glob.sync.mockReturnValue([
-        '/path/to/output/0003.png',
-        '/path/to/output/0004.png',
-        '/path/to/output/0005.png',
-      ]);
-
-      await helpers.generateVideo.call(video);
-
-      expect(fsMocks.copySync).not.toHaveBeenCalled();
-      expect(logger.mock.calls.length).toBe(0);
-    });
-
-    it('should still fill gaps even when initial frames are missing', async () => {
-      // missing first frame doesn't affect ffmpeg
-      video.recordingPath = '/path/to/output';
-      glob.sync.mockReturnValue([
-        '/path/to/output/0003.png',
-        '/path/to/output/0004.png',
-        '/path/to/output/0007.png',
-      ]);
-
-      await helpers.generateVideo.call(video);
-
-      expect(fsMocks.copySync).toHaveBeenCalledTimes(2);
-      expect(fsMocks.copySync.mock.calls[0][0]).toBe('/path/to/output/0004.png');
-      expect(fsMocks.copySync.mock.calls[0][1]).toBe('/path/to/output/0005.png');
-      expect(fsMocks.copySync.mock.calls[1][0]).toBe('/path/to/output/0004.png');
-      expect(fsMocks.copySync.mock.calls[1][1]).toBe('/path/to/output/0006.png');
-      expect(logger.mock.calls.length).toBe(2);
-    });
-});
-
+  });
 
   describe('waitForVideos - ', () => {
     let videos = [

--- a/src/helpers.spec.js
+++ b/src/helpers.spec.js
@@ -177,7 +177,7 @@ describe('Helpers - ', () => {
 
     afterEach(() => {
       glob.sync = originalGlobSync;
-    })
+    });
 
     it('should not add video attachment placeholder to Allure, if not using Allure', () => {
       helpers.generateVideo.call(video);
@@ -266,20 +266,38 @@ describe('Helpers - ', () => {
       expect(fsMocks.copySync.mock.calls[2][1]).toBe('/path/to/output/0004.png');
     });
 
-    it('should disregard a missing first frame', async () => {
+    it('should disregard missing initial frames', async () => {
       // missing first frame doesn't affect ffmpeg
       video.recordingPath = '/path/to/output';
       glob.sync.mockReturnValue([
-        '/path/to/output/0001.png',
-        '/path/to/output/0002.png',
         '/path/to/output/0003.png',
+        '/path/to/output/0004.png',
+        '/path/to/output/0005.png',
       ]);
 
       await helpers.generateVideo.call(video);
 
       expect(fsMocks.copySync).not.toHaveBeenCalled();
     });
-  });
+
+    it('should still fill gaps even when initial frames are missing', async () => {
+      // missing first frame doesn't affect ffmpeg
+      video.recordingPath = '/path/to/output';
+      glob.sync.mockReturnValue([
+        '/path/to/output/0003.png',
+        '/path/to/output/0004.png',
+        '/path/to/output/0007.png',
+      ]);
+
+      await helpers.generateVideo.call(video);
+
+      expect(fsMocks.copySync).toHaveBeenCalledTimes(2);
+      expect(fsMocks.copySync.mock.calls[0][0]).toBe('/path/to/output/0004.png');
+      expect(fsMocks.copySync.mock.calls[0][1]).toBe('/path/to/output/0005.png');
+      expect(fsMocks.copySync.mock.calls[1][0]).toBe('/path/to/output/0004.png');
+      expect(fsMocks.copySync.mock.calls[1][1]).toBe('/path/to/output/0006.png');
+    });
+});
 
 
   describe('waitForVideos - ', () => {

--- a/src/helpers.spec.js
+++ b/src/helpers.spec.js
@@ -179,7 +179,7 @@ describe('Helpers - ', () => {
     });
 
     it('should skip calling ffmpeg if the frame search promise is rejected', async () => {
-      globMocks.glob = jest.fn((pattern, options, cb) => cb(new Error('failed to find frames')));
+      globMocks.glob = jest.fn((pattern, cb) => cb(new Error('failed to find frames')));
 
       await expect(helpers.generateVideo.call(video)).rejects.toThrow(Error);
       expect(videoPromiseResolved).toBeFalsy();
@@ -189,7 +189,7 @@ describe('Helpers - ', () => {
     describe('missing frame mitigation - ', () => {
       it('should not insert frames if all are present', async () => {
         video.recordingPath = '/path/to/output';
-        globMocks.glob = jest.fn((pattern, options, cb) => cb(null, [
+        globMocks.glob = jest.fn((pattern, cb) => cb(null, [
           '/path/to/output/0000.png',
           '/path/to/output/0001.png',
           '/path/to/output/0002.png',
@@ -208,7 +208,7 @@ describe('Helpers - ', () => {
       it('should insert missing frames before calling ffmpeg', async () => {
         // should non-destructively copy 0003.png to replace the missing 0004.png
         video.recordingPath = '/path/to/output';
-        globMocks.glob = jest.fn((pattern, options, cb) => cb(null, [
+        globMocks.glob = jest.fn((pattern, cb) => cb(null, [
           '/path/to/output/0000.png',
           '/path/to/output/0001.png',
           '/path/to/output/0002.png',
@@ -228,7 +228,7 @@ describe('Helpers - ', () => {
       it('should compensate for multiple missing frames before calling ffmpeg', async () => {
         // should non-destructively copy 0003.png to replace the missing 0004.png
         video.recordingPath = '/path/to/output';
-        globMocks.glob = jest.fn((pattern, options, cb) => cb(null, [
+        globMocks.glob = jest.fn((pattern, cb) => cb(null, [
           '/path/to/output/0000.png',
           '/path/to/output/0001.png',
           '/path/to/output/0005.png',
@@ -250,7 +250,7 @@ describe('Helpers - ', () => {
       it('should disregard missing initial frames', async () => {
         // missing first frame doesn't affect ffmpeg
         video.recordingPath = '/path/to/output';
-        globMocks.glob = jest.fn((pattern, options, cb) => cb(null, [
+        globMocks.glob = jest.fn((pattern, cb) => cb(null, [
           '/path/to/output/0003.png',
           '/path/to/output/0004.png',
           '/path/to/output/0005.png',
@@ -265,7 +265,7 @@ describe('Helpers - ', () => {
       it('should still fill gaps even when initial frames are missing', async () => {
         // missing first frame doesn't affect ffmpeg
         video.recordingPath = '/path/to/output';
-        globMocks.glob = jest.fn((pattern, options, cb) => cb(null, [
+        globMocks.glob = jest.fn((pattern, cb) => cb(null, [
           '/path/to/output/0003.png',
           '/path/to/output/0004.png',
           '/path/to/output/0007.png',

--- a/src/index.js
+++ b/src/index.js
@@ -155,6 +155,12 @@ export default class Video extends WdioReporter {
   onTestStart (test) {
     this.framework.onTestStart.call(this, test);
 
+    // Create the report directory, if it does not exists
+    if (!fs.existsSync(this.recordingPath)) {
+      helpers.debugLog(`Creating: ${this.recordingPath}, as it not exists...\n`);
+      fs.mkdirsSync(this.recordingPath);
+    }
+
     if (config.screenshotIntervalSecs) {
       const instance = this;
       this.intervalScreenshot = setInterval(() => instance.addFrame(), config.screenshotIntervalSecs * 1000);
@@ -263,13 +269,7 @@ export default class Video extends WdioReporter {
 
   addFrame () {
     const frame = this.frameNr++;
-    const filePath = path.resolve(this.recordingPath, frame.toString().padStart(4, '0') + '.png');
-
-    // Create the report directory, if it does not exists
-    if (!fs.existsSync(this.recordingPath)) {
-      helpers.debugLog(`Creating: ${this.recordingPath}, as it not exists...\n`);
-      fs.mkdirsSync(this.recordingPath);
-    }
+    const filePath = path.resolve(this.recordingPath, frame.toString().padStart(config.screenshotPaddingWidth, '0') + '.png');
 
     try {
       this.screenshotPromises.push(

--- a/src/index.js
+++ b/src/index.js
@@ -212,6 +212,7 @@ export default class Video extends WdioReporter {
    * Wait for all ffmpeg-processes to finish
    */
   onRunnerEnd () {
+    helpers.debugLog(`starting onRunnerEnd\n`);
     let abortTimer;
     let started = false;
     const wrapItUp = () => {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -543,31 +543,6 @@ describe('wdio-video-recorder - ', () => {
         video.onAfterCommand({endpoint: '/nothing-to-see-here/'});
         expect(video.frameNr).toBe(0);
       });
-
-      it('should not create recordingPath if exists', (done) => {
-        let video = new Video(options);
-        video.recordingPath = 'folder';
-        helpers.default.debugLog = jest.fn();
-        fsMocks.existsSync = jest.fn().mockReturnValue(true);
-        video.onAfterCommand({endpoint: '/session/abcdef/' + originalConfig.jsonWireActions[0]});
-        setImmediate(() => {
-          expect(fsMocks.mkdirsSync).toBeCalledTimes(0);
-          done();
-        });
-      });
-
-      it('should create recordingPath if not exists', (done) => {
-        let video = new Video(options);
-        video.recordingPath = 'folder';
-        helpers.default.debugLog = jest.fn();
-        fsMocks.existsSync = jest.fn().mockReturnValue(false);
-        video.onAfterCommand({endpoint: '/session/abcdef/' + originalConfig.jsonWireActions[0]});
-        setImmediate(() => {
-          expect(fsMocks.mkdirsSync).toBeCalledTimes(1);
-          done();
-        });
-      });
-
     });
 
     describe('should create video frame when -', () => {
@@ -685,6 +660,36 @@ describe('wdio-video-recorder - ', () => {
     afterEach(() => {
       jest.useRealTimers();
     });
+
+
+    it('should not create recordingPath if exists', (done) => {
+      let video = new Video(options);
+      video.framework = {
+        onTestStart: jest.fn(),
+      };
+      video.recordingPath = 'folder';
+      fsMocks.existsSync = jest.fn().mockReturnValue(true);
+      video.onTestStart({title: 'TEST'});
+      setImmediate(() => {
+        expect(fsMocks.mkdirsSync).toBeCalledTimes(0);
+        done();
+      });
+    });
+
+    it('should create recordingPath if not exists', (done) => {
+      let video = new Video(options);
+      video.framework = {
+        onTestStart: jest.fn(),
+      };
+      video.recordingPath = 'folder';
+      fsMocks.existsSync = jest.fn().mockReturnValue(false);
+      video.onTestStart({title: 'TEST'});
+      setImmediate(() => {
+        expect(fsMocks.mkdirsSync).toBeCalledTimes(1);
+        done();
+      });
+    });
+
     it('should call frameworks onTestStart', () => {
       let video = new Video(options);
       video.framework = {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -505,7 +505,54 @@ describe('wdio-video-recorder - ', () => {
         expect(video.runnerInstance).toBeDefined();
       });
     });
+  });
 
+  describe('onBeforeCommand - ', () => {
+    it('should add a video attachment placeholder to Allure, if using Allure', async () => {
+      allureMocks.addAttachment = jest.fn();
+      configModule.default.usingAllure = true;
+      let video = new Video(options);
+      video.testname = 'first-test';
+
+      video.onBeforeCommand();
+      expect(allureMocks.addAttachment).toHaveBeenCalledTimes(1);
+      expect(allureMocks.addAttachment).toHaveBeenCalledWith('Execution video', 'outputDir/first-test.mp4', 'video/mp4');
+    });
+
+    it('should only add a video attachment once for each test', async () => {
+      allureMocks.addAttachment = jest.fn();
+      configModule.default.usingAllure = true;
+      let video = new Video(options);
+      video.testname = 'first-test';
+
+      video.onBeforeCommand();
+      video.onBeforeCommand();
+      video.onBeforeCommand();
+
+      video.testname = 'second-test';
+      video.onBeforeCommand();
+      video.onBeforeCommand();
+
+      video.testname = 'third-test';
+      video.onBeforeCommand();
+      video.onBeforeCommand();
+      video.onBeforeCommand();
+
+      expect(allureMocks.addAttachment).toHaveBeenCalledTimes(3);
+      expect(allureMocks.addAttachment).toHaveBeenCalledWith('Execution video', 'outputDir/first-test.mp4', 'video/mp4');
+      expect(allureMocks.addAttachment).toHaveBeenCalledWith('Execution video', 'outputDir/second-test.mp4', 'video/mp4');
+      expect(allureMocks.addAttachment).toHaveBeenCalledWith('Execution video', 'outputDir/third-test.mp4', 'video/mp4');
+    });
+
+    it('should not add video attachment placeholders to Allure, if not using Allure', async () => {
+      allureMocks.addAttachment = jest.fn();
+      configModule.default.usingAllure = false;
+      let video = new Video(options);
+      video.testname = 'first-test';
+
+      video.onBeforeCommand();
+      expect(allureMocks.addAttachment).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('onAfterCommand - ', () => {
@@ -560,26 +607,23 @@ describe('wdio-video-recorder - ', () => {
         expect(browser.saveScreenshot).toHaveBeenCalledWith('folder/0002.png');
       });
 
-      it('saveScreenshot fails, by saving notAvailable.png', () => {
-        browser.saveScreenshot.mockImplementationOnce(() => {
-          throw 'error';
-        });
-        browser.saveScreenshot.mockImplementationOnce(() => {
-          throw 'error';
-        });
-        browser.saveScreenshot.mockImplementationOnce(() => {
-          throw 'error';
-        });
+      it('saveScreenshot fails, by saving notAvailable.png', async () => {
+        browser.saveScreenshot.mockRejectedValueOnce(new Error('error'));
+        browser.saveScreenshot.mockRejectedValueOnce(new Error('error'));
+        browser.saveScreenshot.mockRejectedValueOnce(new Error('error'));
         let video = new Video(options);
         video.recordingPath = 'folder';
 
         video.onAfterCommand({endpoint: '/session/abcdef/' + originalConfig.jsonWireActions[0]});
+        await flushPromises();
         expect(fsMocks.writeFile).toHaveBeenCalledWith('folder/0000.png', 'file-mock', 'base64');
 
         video.onAfterCommand({endpoint: '/session/abcdef/' + originalConfig.jsonWireActions[0]});
+        await flushPromises();
         expect(fsMocks.writeFile).toHaveBeenCalledWith('folder/0001.png', 'file-mock', 'base64');
 
         video.onAfterCommand({endpoint: '/session/abcdef/' + originalConfig.jsonWireActions[0]});
+        await flushPromises();
         expect(fsMocks.writeFile).toHaveBeenCalledWith('folder/0002.png', 'file-mock', 'base64');
       });
 
@@ -789,14 +833,16 @@ describe('wdio-video-recorder - ', () => {
       helpers.default.generateVideo = jest.fn();
     });
 
-    it('should remove test title from testnameStructure', () => {
+    it('should remove test title from testnameStructure', async () => {
       let video = new Video(options);
       video.testnameStructure = ['DESCRIBE1', 'DESCRIBE2', 'DESCRIBE3', 'TEST'];
       video.onTestEnd({title: 'TEST'});
+      await flushPromises();
+
       expect(video.testnameStructure).toEqual(['DESCRIBE1', 'DESCRIBE2', 'DESCRIBE3']);
     });
 
-    it('should add deviceType as argument to allure', () => {
+    it('should add deviceType as argument to allure', async () => {
       global.browser.capabilities.deviceType = 'myDevice';
 
       configModule.default.usingAllure = false;
@@ -812,10 +858,12 @@ describe('wdio-video-recorder - ', () => {
       video.capabilities = global.browser.capabilities;
       video.testname = undefined;
       video.onTestEnd({title: 'TEST', state: 'passed'});
+      await flushPromises();
+
       expect(allureMocks.addArgument).toHaveBeenCalledWith('deviceType', 'myDevice');
     });
 
-    it('should add browserVersion as argument to allure', () => {
+    it('should add browserVersion as argument to allure', async () => {
       global.browser.capabilities.browserVersion = '1.2.3';
 
       configModule.default.usingAllure = false;
@@ -831,24 +879,30 @@ describe('wdio-video-recorder - ', () => {
       video.capabilities = global.browser.capabilities;
       video.testname = undefined;
       video.onTestEnd({title: 'TEST', state: 'passed'});
+      await flushPromises();
+
       expect(allureMocks.addArgument).toHaveBeenCalledWith('browserVersion', '1.2.3');
     });
 
-    it('should not take a last screenshot if test passed', () => {
+    it('should not take a last screenshot if test passed', async () => {
       let video = new Video(options);
       video.recordingPath = 'folder';
 
       video.onTestEnd({title: 'TEST', state: 'passed'});
+      await flushPromises();
+
       expect(browser.saveScreenshot).not.toHaveBeenCalledWith('folder/0000.png');
     });
 
-    it('should take a last screenshot if test failed', (done) => {
+    it('should take a last screenshot if test failed', async (done) => {
       helpers.default.debugLog = jest.fn();
 
       let video = new Video(options);
       video.recordingPath = 'folder';
 
       video.onTestEnd({title: 'TEST', state: 'failed'});
+      await flushPromises();
+
       expect(browser.saveScreenshot).toHaveBeenCalledWith('folder/0000.png');
       setImmediate(() => {
         expect(helpers.default.debugLog).toHaveBeenCalledWith('- Screenshot!! (frame: 0)\n');
@@ -856,50 +910,56 @@ describe('wdio-video-recorder - ', () => {
       });
     });
 
-    it('should take a last screenshot if test passed and config saveAllvideos', () => {
+    it('should take a last screenshot if test passed and config saveAllvideos', async () => {
       options.saveAllVideos = true;
       let video = new Video(options);
       video.recordingPath = 'folder';
 
       video.onTestEnd({title: 'TEST', state: 'passed'});
+      await flushPromises();
+
       expect(browser.saveScreenshot).toHaveBeenCalledWith('folder/0000.png');
     });
 
-    it('should write notAvailable.png as last screenshot if saveScreenshot fails', () => {
-      browser.saveScreenshot.mockImplementationOnce(() => {
-        throw 'error';
-      });
+    it('should write notAvailable.png as last screenshot if saveScreenshot fails', async () => {
+      browser.saveScreenshot.mockRejectedValueOnce(new Error('error'));
       let video = new Video(options);
       video.recordingPath = 'folder';
 
       video.onTestEnd({title: 'TEST', state: 'failed'});
+      await flushPromises();
       expect(fsMocks.writeFile).toHaveBeenCalledWith('folder/0000.png', 'file-mock', 'base64');
     });
 
-    it('should generate videos for failed tests', () => {
+    it('should generate videos for failed tests', async () => {
       let video = new Video(options);
       video.recordingPath = 'folder';
       video.onTestEnd({title: 'TEST', state: 'failed'});
+      await flushPromises();
 
       expect(helpers.default.generateVideo).toHaveBeenCalled();
     });
 
-    it('should not generate videos for passed tests', () => {
+    it('should not generate videos for passed tests', async () => {
       let video = new Video(options);
       video.recordingPath = 'folder';
       video.onTestEnd({title: 'TEST', state: 'passed'});
+      await flushPromises();
+
       expect(helpers.default.generateVideo).not.toHaveBeenCalled();
     });
 
-    it('should generate videos for passed tests when saveAllVideos is set', () => {
+    it('should generate videos for passed tests when saveAllVideos is set', async () => {
       options.saveAllVideos = true;
       let video = new Video(options);
       video.recordingPath = 'folder';
       video.onTestEnd({title: 'TEST', state: 'passed'});
+      await flushPromises();
+
       expect(helpers.default.generateVideo).toHaveBeenCalled();
     });
 
-    it('should stop interval screenshots if running', () => {
+    it('should stop interval screenshots if running', async () => {
       global.clearInterval = jest.fn();
       const interval = jest.fn();
       let video = new Video(options);
@@ -908,6 +968,8 @@ describe('wdio-video-recorder - ', () => {
         onTestEnd: jest.fn(),
       };
       video.onTestEnd({title: 'TEST'});
+      await flushPromises();
+
       expect(global.clearInterval).toHaveBeenCalledWith(interval);
     });
   });
@@ -1011,6 +1073,27 @@ describe('wdio-video-recorder - ', () => {
       await flushPromises();
 
       expect(video.write).not.toHaveBeenCalled();
+    });
+
+    it('should report a rejected video promise and wrapup immediately', async () => {
+      global.clearTimeout = jest.fn();
+      let video = new Video(options);
+      video.videos = videos;
+      video.write = jest.fn();
+
+      let reject;
+      const videoDonePromise = new Promise((res, rej) => { reject = rej; });
+      video.videoPromises.push(videoDonePromise);
+      video.onRunnerEnd();
+      await flushPromises();
+      expect(global.clearTimeout.mock.calls.length).toBe(0);
+      expect(video.write).not.toHaveBeenCalled();
+
+      reject(new Error('error'));
+      await flushPromises();
+
+      expect(global.clearTimeout.mock.calls.length).toBe(1);
+      expect(video.write).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Addresses issue https://github.com/webdriverio-community/wdio-video-reporter/issues/91

Fix incomplete videos by inserting missing screenshots (copied from the last known good screenshot) before calling ffmpeg

Adopt a different `helpers.sleep()` strategy, this time leveraging `Atomics.wait()` so that it's compatible with being called via `process.on`
 
Also, revisit where allure.addAttachment() is called to help avoid the video being misassigned or
buried within multiple screenshot substeps in the Allure report.