### PR TITLE
[FIX] Prevent last screenshots in Cucumber from throwing an error

### DIFF
--- a/src/frameworks/cucumber.js
+++ b/src/frameworks/cucumber.js
@@ -89,13 +89,13 @@ export default {
           this.recordingPath,
           this.frameNr.toString().padStart(config.screenshotPaddingWidth, '0') + '.png'
         );
-        try {
-          browser.saveScreenshot(filePath);
-          helpers.debugLog('- Screenshot!!\n');
-        } catch (e) {
-          fs.writeFile(filePath, notAvailableImage, 'base64');
-          helpers.debugLog('- Screenshot not available...\n');
-        }
+
+        browser.saveScreenshot(filePath)
+          .then(() => helpers.debugLog(`- Screenshot!! (frame: ${this.frameNr})\n`))
+          .catch((error) => {
+            fs.writeFile(filePath, notAvailableImage, 'base64');
+            helpers.debugLog(`- Screenshot not available (frame: ${this.frameNr}). Error: ${error}..\n`);
+          });
 
         helpers.generateVideo.call(this);
       }

--- a/src/frameworks/cucumber.spec.js
+++ b/src/frameworks/cucumber.spec.js
@@ -54,7 +54,7 @@ describe('wdio-video-recorder - cucumber framework - ', () => {
     });
 
     global.browser = {
-      saveScreenshot: jest.fn(),
+      saveScreenshot: jest.fn(() => Promise.resolve()),
       capabilities: {
         browserName: 'BROWSER',
       },
@@ -321,8 +321,9 @@ describe('wdio-video-recorder - cucumber framework - ', () => {
       });
 
       it('should write notAvailable.png as last screenshot if saveScreenshot fails', () => {
-        browser.saveScreenshot.mockImplementationOnce(() => {
-          throw 'error';
+        browser.saveScreenshot.mockReturnValueOnce({
+          then: jest.fn().mockReturnThis(),
+          catch: jest.fn().mockImplementationOnce((callback) => { callback(); }),
         });
         let video = new Video(options);
         video.recordingPath = 'folder';


### PR DESCRIPTION
We recently updated to wdio v8, along with all our reporter dependencies. After the update, we noticed `wdio-video-reporter 4.0.1` was crashing at the end of every test, and narrowed it down to the final screenshot that takes place in the `onSuiteEnd` handler. It seems like this last screenshot attempt is always being made on a session that no longer exists.

Since `browser.saveScreenshot` is async, the try/catch wasn't properly handling any errors. This PR attempts to fix that, and updates the tests as well.

This should also be revisited at some point to see if there's a better place to take a final screenshot, I'm pretty sure this call will always be failing (at least in our testing suite).

- [x]  `yarn lint` passing
- [x] `yarn test` passing
- [x] `yarn build` passing