### PR TITLE
Fallback for outputDir setting & clean up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -687,9 +687,9 @@
       "dev": true
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.11.tgz",
-      "integrity": "sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
       "cpu": [
         "ppc64"
       ],
@@ -703,9 +703,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.11.tgz",
-      "integrity": "sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
       "cpu": [
         "arm"
       ],
@@ -719,9 +719,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.11.tgz",
-      "integrity": "sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
       "cpu": [
         "arm64"
       ],
@@ -735,9 +735,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.11.tgz",
-      "integrity": "sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
       "cpu": [
         "x64"
       ],
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.11.tgz",
-      "integrity": "sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
       "cpu": [
         "arm64"
       ],
@@ -767,9 +767,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.11.tgz",
-      "integrity": "sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
       "cpu": [
         "x64"
       ],
@@ -783,9 +783,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.11.tgz",
-      "integrity": "sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
       "cpu": [
         "arm64"
       ],
@@ -799,9 +799,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.11.tgz",
-      "integrity": "sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
       "cpu": [
         "x64"
       ],
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.11.tgz",
-      "integrity": "sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
       "cpu": [
         "arm"
       ],
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.11.tgz",
-      "integrity": "sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
       "cpu": [
         "arm64"
       ],
@@ -847,9 +847,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.11.tgz",
-      "integrity": "sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
       "cpu": [
         "ia32"
       ],
@@ -863,9 +863,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.11.tgz",
-      "integrity": "sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
       "cpu": [
         "loong64"
       ],
@@ -879,9 +879,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.11.tgz",
-      "integrity": "sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
       "cpu": [
         "mips64el"
       ],
@@ -895,9 +895,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.11.tgz",
-      "integrity": "sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
       "cpu": [
         "ppc64"
       ],
@@ -911,9 +911,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.11.tgz",
-      "integrity": "sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
       "cpu": [
         "riscv64"
       ],
@@ -927,9 +927,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.11.tgz",
-      "integrity": "sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
       "cpu": [
         "s390x"
       ],
@@ -943,9 +943,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.11.tgz",
-      "integrity": "sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
       "cpu": [
         "x64"
       ],
@@ -959,9 +959,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.11.tgz",
-      "integrity": "sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
       "cpu": [
         "x64"
       ],
@@ -975,9 +975,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.11.tgz",
-      "integrity": "sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
       "cpu": [
         "x64"
       ],
@@ -991,9 +991,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.11.tgz",
-      "integrity": "sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
       "cpu": [
         "x64"
       ],
@@ -1007,9 +1007,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.11.tgz",
-      "integrity": "sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
       "cpu": [
         "arm64"
       ],
@@ -1023,9 +1023,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.11.tgz",
-      "integrity": "sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
       "cpu": [
         "ia32"
       ],
@@ -1039,9 +1039,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.11.tgz",
-      "integrity": "sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
       "cpu": [
         "x64"
       ],
@@ -2576,13 +2576,13 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.2.1.tgz",
-      "integrity": "sha512-/bqGXcHfyKgFWYwIgFr1QYDaR9e64pRKxgBNWNXPefPFRhgm+K3+a/dS0cUGEreWngets3dlr8w8SBRw2fCfFQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.2.2.tgz",
+      "integrity": "sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "1.2.1",
-        "@vitest/utils": "1.2.1",
+        "@vitest/spy": "1.2.2",
+        "@vitest/utils": "1.2.2",
         "chai": "^4.3.10"
       },
       "funding": {
@@ -2590,12 +2590,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.2.1.tgz",
-      "integrity": "sha512-zc2dP5LQpzNzbpaBt7OeYAvmIsRS1KpZQw4G3WM/yqSV1cQKNKwLGmnm79GyZZjMhQGlRcSFMImLjZaUQvNVZQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.2.2.tgz",
+      "integrity": "sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "1.2.1",
+        "@vitest/utils": "1.2.2",
         "p-limit": "^5.0.0",
         "pathe": "^1.1.1"
       },
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.2.1.tgz",
-      "integrity": "sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.2.2.tgz",
+      "integrity": "sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==",
       "devOptional": true,
       "dependencies": {
         "magic-string": "^0.30.5",
@@ -2645,9 +2645,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.2.1.tgz",
-      "integrity": "sha512-vG3a/b7INKH7L49Lbp0IWrG6sw9j4waWAucwnksPB1r1FTJgV7nkBByd9ufzu6VWya/QTvQW4V9FShZbZIB2UQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.2.2.tgz",
+      "integrity": "sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.2.0"
@@ -2657,9 +2657,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.2.1.tgz",
-      "integrity": "sha512-bsH6WVZYe/J2v3+81M5LDU8kW76xWObKIURpPrOXm2pjBniBu2MERI/XP60GpS4PHU3jyK50LUutOwrx4CyHUg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.2.2.tgz",
+      "integrity": "sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==",
       "dev": true,
       "dependencies": {
         "diff-sequences": "^29.6.3",
@@ -5283,9 +5283,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.11.tgz",
-      "integrity": "sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -5295,29 +5295,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.19.11",
-        "@esbuild/android-arm": "0.19.11",
-        "@esbuild/android-arm64": "0.19.11",
-        "@esbuild/android-x64": "0.19.11",
-        "@esbuild/darwin-arm64": "0.19.11",
-        "@esbuild/darwin-x64": "0.19.11",
-        "@esbuild/freebsd-arm64": "0.19.11",
-        "@esbuild/freebsd-x64": "0.19.11",
-        "@esbuild/linux-arm": "0.19.11",
-        "@esbuild/linux-arm64": "0.19.11",
-        "@esbuild/linux-ia32": "0.19.11",
-        "@esbuild/linux-loong64": "0.19.11",
-        "@esbuild/linux-mips64el": "0.19.11",
-        "@esbuild/linux-ppc64": "0.19.11",
-        "@esbuild/linux-riscv64": "0.19.11",
-        "@esbuild/linux-s390x": "0.19.11",
-        "@esbuild/linux-x64": "0.19.11",
-        "@esbuild/netbsd-x64": "0.19.11",
-        "@esbuild/openbsd-x64": "0.19.11",
-        "@esbuild/sunos-x64": "0.19.11",
-        "@esbuild/win32-arm64": "0.19.11",
-        "@esbuild/win32-ia32": "0.19.11",
-        "@esbuild/win32-x64": "0.19.11"
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
       }
     },
     "node_modules/escalade": {
@@ -12939,9 +12939,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.2.1.tgz",
-      "integrity": "sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.2.2.tgz",
+      "integrity": "sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -12961,16 +12961,16 @@
       }
     },
     "node_modules/vitest": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.2.1.tgz",
-      "integrity": "sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.2.2.tgz",
+      "integrity": "sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "1.2.1",
-        "@vitest/runner": "1.2.1",
-        "@vitest/snapshot": "1.2.1",
-        "@vitest/spy": "1.2.1",
-        "@vitest/utils": "1.2.1",
+        "@vitest/expect": "1.2.2",
+        "@vitest/runner": "1.2.2",
+        "@vitest/snapshot": "1.2.2",
+        "@vitest/spy": "1.2.2",
+        "@vitest/utils": "1.2.2",
         "acorn-walk": "^8.3.2",
         "cac": "^6.7.14",
         "chai": "^4.3.10",
@@ -12983,9 +12983,9 @@
         "std-env": "^3.5.0",
         "strip-literal": "^1.3.0",
         "tinybench": "^2.5.1",
-        "tinypool": "^0.8.1",
+        "tinypool": "^0.8.2",
         "vite": "^5.0.0",
-        "vite-node": "1.2.1",
+        "vite-node": "1.2.2",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -207,7 +207,7 @@ describe('waitForVideosToBeWritten', () => {
       .mockImplementationOnce(() => ({ size: 73 } as any))
       .mockImplementation(() => ({ size: 512 } as any))
     const sleepMock = vi.fn().mockImplementation(sleep)
-    expect(waitForVideosToBeWritten(videos, 200, sleepMock)).toBe(false)
+    expect(waitForVideosToBeWritten(videos, 150, sleepMock)).toBe(false)
     expect(sleepMock).toBeCalledTimes(2)
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -104,6 +104,15 @@ describe('Video Reporter', () => {
       expect(vi.mocked(process.on)).toBeCalledTimes(1)
     })
 
+    it('sets outputDir to default value if not configured', () => {
+      const reporter = new VideoReporter({})
+      reporter.onRunnerStart({
+        ...allureRunner,
+        config: {}
+      })
+      expect(reporter.outputDir).toEqual('_results_')
+    })
+
     it('should set record to true', () => {
       const reporter = new VideoReporter({})
       reporter.onRunnerStart(allureRunner)

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,9 @@ export default class VideoReporter extends WdioReporter {
       return
     }
 
-    this.#outputDir = runner.config.outputDir as string
+    this.#outputDir = this.options.outputDir ?? runner.config.outputDir as string;
+    this.#outputDir = this.#outputDir ?? '_results_';
+
     const sessionId = runner.isMultiremote
       ? Object.entries(runner.capabilities).map(([, caps]) => caps.sessionId)[0] as string
       : runner.sessionId
@@ -324,7 +326,9 @@ export default class VideoReporter extends WdioReporter {
 
     this.screenshotPromises.push(
       browser.saveScreenshot(filePath)
-        .then(() => this.#log(`- Screenshot (frame: ${frame})`))
+        .then(() => {
+          this.#log(`- Screenshot (frame: ${frame})`)
+        })
         .catch((error: Error) => {
           fs.writeFileSync(filePath, notAvailableImage, 'base64')
           this.#log(`Screenshot not available (frame: ${frame}). Error: ${error}..`)
@@ -445,7 +449,7 @@ export default class VideoReporter extends WdioReporter {
 
     const testName = this.testName = generateFilename(this.options.maxTestNameCharacters, browserName, fullName)
     this.frameNr = 0
-    this.recordingPath = path.resolve(this.#outputDir ?? this.options.outputDir, this.options.rawPath, testName)
+    this.recordingPath = path.resolve(this.#outputDir, this.options.rawPath, testName)
 
     fs.mkdirSync(this.recordingPath, { recursive: true })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export default class VideoReporter extends WdioReporter {
   #allureOutputDir?: string
   #allureReporter = new AllureReporterExtension()
   #record = true
+  #defaultOutputDir = '_results_'
 
   screenshotPromises: Promise<void>[] = []
   videos: string[] = []
@@ -64,6 +65,11 @@ export default class VideoReporter extends WdioReporter {
   /**
    * set getter to verify values for testing purposes
    */
+  get outputDir () { return this.#outputDir }
+
+  /**
+   * set getter to verify values for testing purposes
+   */
   get allureOutputDir () { return this.#allureOutputDir }
 
   /**
@@ -86,7 +92,7 @@ export default class VideoReporter extends WdioReporter {
     }
 
     this.#outputDir = this.options.outputDir ?? runner.config.outputDir as string
-    this.#outputDir = this.#outputDir ?? '_results_'
+    this.#outputDir = this.#outputDir ?? this.#defaultOutputDir
     const sessionId = runner.isMultiremote
       ? Object.entries(runner.capabilities).map(([, caps]) => caps.sessionId)[0] as string
       : runner.sessionId

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,17 +165,17 @@ export default class VideoReporter extends WdioReporter {
    */
   onSuiteStart (suite: SuiteStats) {
     if (!this.#record) {
-            return
+      return
     }
 
     if (this.isCucumberFramework) {
-            this.testNameStructure.push(suite.title.replace(/ /g, '-').replace(/-{2,}/g, '-'))
+      this.testNameStructure.push(suite.title.replace(/ /g, '-').replace(/-{2,}/g, '-'))
     }
 
     if (suite.type === 'scenario') {
-            this.#setRecordingPath()
+      this.#setRecordingPath()
     }
-      }
+  }
 
   /**
    * Cleare suite name from naming structure
@@ -204,17 +204,17 @@ export default class VideoReporter extends WdioReporter {
    * Setup filename based on test name and prepare storage directory
    */
   onTestStart (suite: TestStats) {
-        if (!this.#record) {
-            return
+    if (!this.#record) {
+      return
     }
 
     if (!this.isCucumberFramework) {
-            this.testNameStructure.push(suite.title.replace(/ /g, '-').replace(/-{2,}/g, '-'))
+      this.testNameStructure.push(suite.title.replace(/ /g, '-').replace(/-{2,}/g, '-'))
     }
-        this.#setRecordingPath()
+    this.#setRecordingPath()
     
     if (this.options.screenshotIntervalSecs) {
-            const instance = this
+      const instance = this
       this.intervalScreenshot = setInterval(
         () => instance.addFrame(),
         this.options.screenshotIntervalSecs * 1000
@@ -226,7 +226,7 @@ export default class VideoReporter extends WdioReporter {
    * Remove empty directories
    */
   onTestSkip () {
-        if (!this.#record) {
+    if (!this.#record) {
       return
     }
 
@@ -255,7 +255,7 @@ export default class VideoReporter extends WdioReporter {
    * Wait for all ffmpeg-processes to finish
    */
   onRunnerEnd () {
-        if (!this.#record) {
+    if (!this.#record) {
       return
     }
 
@@ -285,7 +285,7 @@ export default class VideoReporter extends WdioReporter {
    * Finalize allure report
    */
   onExit () {
-        const allureOutputDir = this.#allureOutputDir
+    const allureOutputDir = this.#allureOutputDir
     if (!allureOutputDir) {
       return
     }
@@ -315,18 +315,18 @@ export default class VideoReporter extends WdioReporter {
   }
 
   addFrame () {
-        if (!this.recordingPath) {
-            return false
+    if (!this.recordingPath) {
+      return false
     }
 
     const frame = this.frameNr++
     const filePath = path.resolve(this.recordingPath, frame.toString().padStart(SCREENSHOT_PADDING_WITH, '0') + '.png')
 
-        this.screenshotPromises.push(
+    this.screenshotPromises.push(
       browser.saveScreenshot(filePath)
         .then(() => this.#log(`- Screenshot (frame: ${frame})`))
         .catch((error: Error) => {
-                    fs.writeFileSync(filePath, notAvailableImage, 'base64')
+          fs.writeFileSync(filePath, notAvailableImage, 'base64')
           this.#log(`Screenshot not available (frame: ${frame}). Error: ${error}..`)
         })
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,8 +85,8 @@ export default class VideoReporter extends WdioReporter {
       return
     }
 
-    this.#outputDir = this.options.outputDir ?? runner.config.outputDir as string;
-    this.#outputDir = this.#outputDir ?? '_results_';
+    this.#outputDir = this.options.outputDir ?? runner.config.outputDir as string
+    this.#outputDir = this.#outputDir ?? '_results_'
     const sessionId = runner.isMultiremote
       ? Object.entries(runner.capabilities).map(([, caps]) => caps.sessionId)[0] as string
       : runner.sessionId

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,9 @@ export default class VideoReporter extends WdioReporter {
    * Set wdio config options
    */
   onRunnerStart (runner: RunnerStats) {
+    console.log('==== onRunnerStart');
     if (this.options.onlyRecordLastFailure && runner.retry !== runner.config.specFileRetries) {
+      console.log('==== onlyRecordLast & retry !== specFileRetries');
       this.#record = false
       return
     }
@@ -92,11 +94,13 @@ export default class VideoReporter extends WdioReporter {
 
     // May not be present in the case were a spawned worker has no tests when running a subset of the test suite.
     if (!sessionId) {
+      console.log('==== NO SEESION FOUND!?');
       return
     }
 
     const runnerInstance = runner.instanceOptions[sessionId] as Options.Testrunner
     if (!runnerInstance) {
+      console.log('==== NO RUNNER INSTACE');
       return
     }
 
@@ -114,12 +118,14 @@ export default class VideoReporter extends WdioReporter {
 
   onBeforeCommand () {
     if (!this.#usingAllure || !this.testName || !this.#record) {
+      console.log('==== onBeforeCommand not using allure... return');
       return
     }
 
     const formatSettings = getVideoFormatSettings(this.options.videoFormat)
     const videoPath = getVideoPath(this.#outputDir, this.testName, formatSettings.fileExtension)
     if (!this.allureVideos.includes(videoPath)) {
+      console.log('==== allure videos doesnt include video path');
       this.allureVideos.push(videoPath)
       this.#log(`Adding execution video attachment as ${videoPath}`)
       this.#allureReporter.addAttachment('Execution video', videoPath, formatSettings.contentType)
@@ -130,7 +136,9 @@ export default class VideoReporter extends WdioReporter {
    * Save screenshot or add not available image movie stills
    */
   onAfterCommand (commandArgs: AfterCommandArgs) {
+      console.log('==== onAfterCommand okay');
     if (!this.#record) {
+      console.log('==== onAfterCommand record not set, return');
       return
     }
 
@@ -164,6 +172,7 @@ export default class VideoReporter extends WdioReporter {
    * Add suite name to naming structure
    */
   onSuiteStart (suite: SuiteStats) {
+      console.log('==== onSuiteStart okay');
     if (!this.#record) {
       return
     }
@@ -181,6 +190,7 @@ export default class VideoReporter extends WdioReporter {
    * Cleare suite name from naming structure
    */
   onSuiteEnd (suite: SuiteStats) {
+      console.log('==== onSuiteEnd okay');
     if (!this.#record) {
       return
     }
@@ -237,6 +247,7 @@ export default class VideoReporter extends WdioReporter {
    * Add attachment to Allure if applicable and start to generate the video (Not applicable to Cucumber)
    */
   onTestEnd (test: TestStats) {
+      console.log('==== onTestEnd okay');
     if (!this.#record) {
       return
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,6 @@ export default class VideoReporter extends WdioReporter {
 
     this.#outputDir = this.options.outputDir ?? runner.config.outputDir as string;
     this.#outputDir = this.#outputDir ?? '_results_';
-
     const sessionId = runner.isMultiremote
       ? Object.entries(runner.capabilities).map(([, caps]) => caps.sessionId)[0] as string
       : runner.sessionId
@@ -325,9 +324,7 @@ export default class VideoReporter extends WdioReporter {
 
     this.screenshotPromises.push(
       browser.saveScreenshot(filePath)
-        .then(() => {
-          this.#log(`- Screenshot (frame: ${frame})`)
-        })
+        .then(() => this.#log(`- Screenshot (frame: ${frame})`))
         .catch((error: Error) => {
           fs.writeFileSync(filePath, notAvailableImage, 'base64')
           this.#log(`Screenshot not available (frame: ${frame}). Error: ${error}..`)
@@ -449,7 +446,6 @@ export default class VideoReporter extends WdioReporter {
     const testName = this.testName = generateFilename(this.options.maxTestNameCharacters, browserName, fullName)
     this.frameNr = 0
     this.recordingPath = path.resolve(this.#outputDir, this.options.rawPath, testName)
-
     fs.mkdirSync(this.recordingPath, { recursive: true })
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,9 +80,7 @@ export default class VideoReporter extends WdioReporter {
    * Set wdio config options
    */
   onRunnerStart (runner: RunnerStats) {
-    console.log('==== onRunnerStart');
     if (this.options.onlyRecordLastFailure && runner.retry !== runner.config.specFileRetries) {
-      console.log('==== onlyRecordLast & retry !== specFileRetries');
       this.#record = false
       return
     }
@@ -94,13 +92,11 @@ export default class VideoReporter extends WdioReporter {
 
     // May not be present in the case were a spawned worker has no tests when running a subset of the test suite.
     if (!sessionId) {
-      console.log('==== NO SEESION FOUND!?');
       return
     }
 
     const runnerInstance = runner.instanceOptions[sessionId] as Options.Testrunner
     if (!runnerInstance) {
-      console.log('==== NO RUNNER INSTACE');
       return
     }
 
@@ -118,14 +114,12 @@ export default class VideoReporter extends WdioReporter {
 
   onBeforeCommand () {
     if (!this.#usingAllure || !this.testName || !this.#record) {
-      console.log('==== onBeforeCommand not using allure... return');
       return
     }
 
     const formatSettings = getVideoFormatSettings(this.options.videoFormat)
     const videoPath = getVideoPath(this.#outputDir, this.testName, formatSettings.fileExtension)
     if (!this.allureVideos.includes(videoPath)) {
-      console.log('==== allure videos doesnt include video path');
       this.allureVideos.push(videoPath)
       this.#log(`Adding execution video attachment as ${videoPath}`)
       this.#allureReporter.addAttachment('Execution video', videoPath, formatSettings.contentType)
@@ -136,9 +130,7 @@ export default class VideoReporter extends WdioReporter {
    * Save screenshot or add not available image movie stills
    */
   onAfterCommand (commandArgs: AfterCommandArgs) {
-      console.log('==== onAfterCommand okay');
     if (!this.#record) {
-      console.log('==== onAfterCommand record not set, return');
       return
     }
 
@@ -172,25 +164,23 @@ export default class VideoReporter extends WdioReporter {
    * Add suite name to naming structure
    */
   onSuiteStart (suite: SuiteStats) {
-      console.log('==== onSuiteStart okay');
     if (!this.#record) {
-      return
+            return
     }
 
     if (this.isCucumberFramework) {
-      this.testNameStructure.push(suite.title.replace(/ /g, '-').replace(/-{2,}/g, '-'))
+            this.testNameStructure.push(suite.title.replace(/ /g, '-').replace(/-{2,}/g, '-'))
     }
 
     if (suite.type === 'scenario') {
-      this.#setRecordingPath()
+            this.#setRecordingPath()
     }
-  }
+      }
 
   /**
    * Cleare suite name from naming structure
    */
   onSuiteEnd (suite: SuiteStats) {
-      console.log('==== onSuiteEnd okay');
     if (!this.#record) {
       return
     }
@@ -214,17 +204,17 @@ export default class VideoReporter extends WdioReporter {
    * Setup filename based on test name and prepare storage directory
    */
   onTestStart (suite: TestStats) {
-    if (!this.#record) {
-      return
+        if (!this.#record) {
+            return
     }
 
     if (!this.isCucumberFramework) {
-      this.testNameStructure.push(suite.title.replace(/ /g, '-').replace(/-{2,}/g, '-'))
+            this.testNameStructure.push(suite.title.replace(/ /g, '-').replace(/-{2,}/g, '-'))
     }
-    this.#setRecordingPath()
-
+        this.#setRecordingPath()
+    
     if (this.options.screenshotIntervalSecs) {
-      const instance = this
+            const instance = this
       this.intervalScreenshot = setInterval(
         () => instance.addFrame(),
         this.options.screenshotIntervalSecs * 1000
@@ -236,7 +226,7 @@ export default class VideoReporter extends WdioReporter {
    * Remove empty directories
    */
   onTestSkip () {
-    if (!this.#record) {
+        if (!this.#record) {
       return
     }
 
@@ -247,7 +237,6 @@ export default class VideoReporter extends WdioReporter {
    * Add attachment to Allure if applicable and start to generate the video (Not applicable to Cucumber)
    */
   onTestEnd (test: TestStats) {
-      console.log('==== onTestEnd okay');
     if (!this.#record) {
       return
     }
@@ -266,7 +255,7 @@ export default class VideoReporter extends WdioReporter {
    * Wait for all ffmpeg-processes to finish
    */
   onRunnerEnd () {
-    if (!this.#record) {
+        if (!this.#record) {
       return
     }
 
@@ -296,7 +285,7 @@ export default class VideoReporter extends WdioReporter {
    * Finalize allure report
    */
   onExit () {
-    const allureOutputDir = this.#allureOutputDir
+        const allureOutputDir = this.#allureOutputDir
     if (!allureOutputDir) {
       return
     }
@@ -326,18 +315,18 @@ export default class VideoReporter extends WdioReporter {
   }
 
   addFrame () {
-    if (!this.recordingPath) {
-      return false
+        if (!this.recordingPath) {
+            return false
     }
 
     const frame = this.frameNr++
     const filePath = path.resolve(this.recordingPath, frame.toString().padStart(SCREENSHOT_PADDING_WITH, '0') + '.png')
 
-    this.screenshotPromises.push(
+        this.screenshotPromises.push(
       browser.saveScreenshot(filePath)
         .then(() => this.#log(`- Screenshot (frame: ${frame})`))
         .catch((error: Error) => {
-          fs.writeFileSync(filePath, notAvailableImage, 'base64')
+                    fs.writeFileSync(filePath, notAvailableImage, 'base64')
           this.#log(`Screenshot not available (frame: ${frame}). Error: ${error}..`)
         })
     )
@@ -456,7 +445,8 @@ export default class VideoReporter extends WdioReporter {
 
     const testName = this.testName = generateFilename(this.options.maxTestNameCharacters, browserName, fullName)
     this.frameNr = 0
-    this.recordingPath = path.resolve(this.#outputDir, this.options.rawPath, testName)
+    this.recordingPath = path.resolve(this.#outputDir ?? this.options.outputDir, this.options.rawPath, testName)
+
     fs.mkdirSync(this.recordingPath, { recursive: true })
   }
 


### PR DESCRIPTION
Implemented basic fallback directory for outputDir in the scenario where it is not set in the capabilities nor the reporter configuration.

My apologies, kicked out the initial PR quickly.