### PR TITLE
Bug: Fix abort timeout in waitForVideosToBeWritten

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -297,10 +297,12 @@ export default class VideoReporter extends WdioReporter {
     }
     const abortTime =  this.options.videoRenderTimeout
 
+    const startTime = new Date().getTime()
+
     waitForVideosToExist(this.videos, abortTime)
     waitForVideosToBeWritten(this.videos, abortTime)
 
-    if (new Date().getTime() > abortTime) {
+    if (new Date().getTime() - startTime > abortTime) {
       console.log('videoRenderTimeout triggered, not all videos finished writing to disk before patching Allure')
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -295,7 +295,7 @@ export default class VideoReporter extends WdioReporter {
     if (!allureOutputDir) {
       return
     }
-    const abortTime = Date.now() + this.options.videoRenderTimeout
+    const abortTime =  this.options.videoRenderTimeout
 
     waitForVideosToExist(this.videos, abortTime)
     waitForVideosToBeWritten(this.videos, abortTime)


### PR DESCRIPTION
This PR fixes `abortTime` value in `waitForVideosToBeWritten` and `waitForVideosToExist` causing script waiting approx 54 years before exit

Please see diff and implementation of `waitForVideosToBeWritten` for details. 

Steps to Reporduce:

1. Set `saveAllVideos = false`
2. Run tests. If any of tests are success - process stucks in infinite loop