### PR TITLE
Set isDone when not recording tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -262,6 +262,7 @@ export default class VideoReporter extends WdioReporter {
    */
   onRunnerEnd () {
     if (!this.#record) {
+      this.#isDone = true
       return
     }
 


### PR DESCRIPTION
When using the onlyRecordLastFailure and specFileRetries you will get the following error after the tests have ran because the reporter will never be synced.

`ERROR @wdio/runner: Error: Some reporters are still unsynced: VideoReporter`