### PR TITLE
Add filenamePrefixSource option for video filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Default: `.video-reporter-screenshots`
 
 Prefix for video filenames by either suite or test name. When using cucumber it will always be suite.
 
-Type: `string`<br>
+Type: `'suite' | 'test'`<br>
 Default: `test`
 
 ### `videoSlowdownMultiplier`

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ Where to save the screenshots for the video.
 Type: `string`<br>
 Default: `.video-reporter-screenshots`
 
+### `filenamePrefixSource`
+
+Prefix for video filenames by either suite or test name. When using cucumber it will always be suite.
+
+Type: `string`<br>
+Default: `test`
+
 ### `videoSlowdownMultiplier`
 
 Integer between [1-100]. Increase if videos are playing to quick.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,9 @@ export const DEFAULT_OPTIONS = {
   // Where to save screenshots
   rawPath: '.video-reporter-screenshots',
 
+  // Prefix for video filenames by either suite or test name
+  filenamePrefixSource: 'test',
+
   // Should all videos be saved, or only from failed tests
   saveAllVideos: false,
 

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -41,25 +41,25 @@ describe('generateFilename - ', () => {
 
   it('should generate name in form: name--browser--date', () => {
     expect(generateFilename(maxTestNameCharacters, browser, name))
-      .toBe(`video-${name}--${browser}--${date}`)
+      .toBe(`${name}--${browser}--${date}`)
   })
 
   it('should replace space with -', () => {
     const testname = name + ' space'
     expect(generateFilename(maxTestNameCharacters, browser, testname))
-      .toBe(`video-${name}-space--${browser}--${date}`)
+      .toBe(`${name}-space--${browser}--${date}`)
   })
 
   it('should replace . with -', () => {
     const testname = name + '.dot'
     expect(generateFilename(maxTestNameCharacters, browser, testname))
-      .toBe(`video-${name}-dot--${browser}--${date}`)
+      .toBe(`${name}-dot--${browser}--${date}`)
   })
 
   it('should remove characters: /?<>\\/:*|"()[]\'<>%', () => {
     const testname = name + '-/?<>\\/:*|"()[]\'<>%comment/'
     expect(generateFilename(maxTestNameCharacters, browser, testname))
-      .toBe(`video-${name}-comment--${browser}--${date}`)
+      .toBe(`${name}-comment--${browser}--${date}`)
   })
 
   it('should keep filenames <= config.maxTestNameCharacters', () => {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,11 +20,8 @@ export function generateFilename (maxTestNameCharacters: number, browserName: st
     .replace(/[ ]/g, '--')
     .replace(/:|\//g, '-') + `-${msec}`
 
-  let filename = 'video-'
-  if (process.env.WDIO_WORKER_ID) {
-    filename += `${process.env.WDIO_WORKER_ID}-`
-  }
-  filename += encodeURIComponent(`${fullName.replace(/\s+/g, '-')}--${browserName}--${timestamp}`)
+  const wdioWorkerText = process.env.WDIO_WORKER_ID ? `${process.env.WDIO_WORKER_ID}-` : ''
+  let filename = encodeURIComponent(`${fullName.replace(/\s+/g, '-')}-${wdioWorkerText}-${browserName}--${timestamp}`)
     .replace(/%../g, '')
     .replace(/\./g, '-')
     .replace(/[/\\?%*:'|"<>()]/g, '')

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -224,10 +224,10 @@ describe('Video Reporter', () => {
     it('should set recordingPath if suite is scenario', () => {
       const reporter = new VideoReporter({})
       reporter.onSuiteStart({ title: 'foo bar', type: 'scenario' } as any)
-      expect(reporter.recordingPath).toEqual(expect.stringContaining('/video-unknown--CHROME--'))
+      expect(reporter.recordingPath).toEqual(expect.stringContaining('/unknown--CHROME--'))
       reporter.isCucumberFramework = true
       reporter.onSuiteStart({ title: 'foo bar', type: 'scenario' } as any)
-      expect(reporter.recordingPath).toEqual(expect.stringContaining('/video-foo-bar--CHROME--'))
+      expect(reporter.recordingPath).toEqual(expect.stringContaining('/foo-bar--CHROME--'))
     })
   })
 
@@ -291,7 +291,7 @@ describe('Video Reporter', () => {
       const reporter = new VideoReporter({})
       reporter.onTestStart({ title: 'foo bar' } as any)
       expect(fs.mkdirSync).toBeCalledWith(
-        expect.stringContaining('/video-foo-bar--CHROME--'),
+        expect.stringContaining('/foo-bar--CHROME--'),
         { recursive: true }
       )
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,7 @@ export default class VideoReporter extends WdioReporter {
       return
     }
 
-    if (this.isCucumberFramework) {
+    if (this.isCucumberFramework || this.options.filenamePrefixSource === 'suite') {
       this.testNameStructure.push(suite.title.replace(/ /g, '-').replace(/-{2,}/g, '-'))
     }
 
@@ -215,7 +215,7 @@ export default class VideoReporter extends WdioReporter {
       return
     }
 
-    if (!this.isCucumberFramework) {
+    if (!this.isCucumberFramework && this.options.filenamePrefixSource === 'test') {
       this.testNameStructure.push(suite.title.replace(/ /g, '-').replace(/-{2,}/g, '-'))
     }
     this.#setRecordingPath()
@@ -248,7 +248,9 @@ export default class VideoReporter extends WdioReporter {
     }
 
     this.clearScreenshotInterval()
-    this.testNameStructure.pop()
+    if (this.options.filenamePrefixSource === 'test' || this.isCucumberFramework) {
+      this.testNameStructure.pop()
+    }
     this.#extendAllureReport()
 
     if (test.state === 'failed' || (test.state === 'passed' && this.options.saveAllVideos)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,12 @@ export interface ReporterOptions extends Reporters.Options {
   rawPath?: string
 
   /**
+   * Prefix for video filenames by either suite or test name
+   * @default 'test'
+   */
+  filenamePrefixSource?: 'test' | 'suite'
+
+  /**
    * Should all videos be saved, or only from failed tests
    * @default false
    */


### PR DESCRIPTION
Adds a new option `filenamePrefixSource` that can be either `test` or `suite`. This will default to `test`.

Currently when videos are outputted the filenames are the test description. With this new option you can specify if you want the test or suite description.

This also removes the `video-` prefix from the filenames along with moving the worker id to after the test or suite description.

Technically could be a breaking change with removing the video- prefix but not sure if there is a specific reason for that or if we should add an option for that as well.