### PR TITLE
Resolve #105 render timeout before wrap - configuration changed

### DIFF
--- a/demo/wdio.conf.ts
+++ b/demo/wdio.conf.ts
@@ -22,7 +22,7 @@ export const config: WebdriverIO.Config = {
     [video, {
       saveAllVideos: false,       // If true, also saves videos for successful test cases
       videoSlowdownMultiplier: 3, // Higher to get slower videos, lower for faster videos [Value 1-100]
-      videoRenderTimeout: 5,      // Max seconds to wait for a video to finish rendering
+      videoRenderTimeout: 5000,      // milliseconds to wait for a video to finish rendering
       videoFormat: 'webm'
     }],
     ['allure', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7107,9 +7107,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
       "devOptional": true
     },
     "node_modules/is-arguments": {
@@ -11931,9 +11931,9 @@
       }
     },
     "node_modules/socks/node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "devOptional": true
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "release:ci": "npm run release -- --ci --npm.skipChecks --no-git.requireCleanWorkingDir",
     "test": "run-s test:*",
     "test:lint": "eslint src",
-    "test:unit": "npx vitest --coverage --run",
+    "test:unit": "LC_ALL=en_US:en npx vitest --coverage --run",
     "watch": "npm run build -- -w"
   },
   "dependencies": {


### PR DESCRIPTION
Resolve #105 - the `videoRenderTimeout` configuration changed from seconds to milliseconds.

Update demo to resolve confusion. Also resolve npm audit warnings and configure locale for test runs to address unexpected filenames during local test