### PR TITLE
(#589) Fixes for disableWebdriverStepReporting param

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "typescript.preferences.includePackageJsonAutoImports": "off",
+  "typescript.validate.enable": false,
+  "typescript.suggest.enabled": false,
+  "files.exclude": {
+    "**/demo/**": false
+  },
+  "typescript.preferences.quoteStyle": "single",
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ]
+}


### PR DESCRIPTION
**Root Cause:** 
The video attachment to Allure reports happens exclusively in the [onBeforeCommand()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) hook (lines 114-124 in [index.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)). When disableWebdriverStepsReporting is set to false (the default), the Allure reporter likely doesn't call or process the [onBeforeCommand()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) hook because it's tracking WebDriver steps, which interferes with the video attachment mechanism.

**The current logic works like this:**
- [onBeforeCommand()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is where videos get attached to Allure reports
- This hook is only called when WebDriver commands are being tracked/reported
- When disableWebdriverStepsReporting: false (default), this hook may not be called consistently or at all
- When disableWebdriverStepsReporting: true, the hook works properly because it's not conflicting with WebDriver step reporting

**The Solution:** 
We need to ensure video attachment happens in a hook that's always called, regardless of the disableWebdriverStepsReporting setting.

**Config Used:**
```
    [video, {
      saveAllVideos: false,       // If true, also saves videos for successful test cases
      videoSlowdownMultiplier: 3, // Higher to get slower videos, lower for faster videos [Value 1-100]
      videoRenderTimeout: 15000,      // milliseconds to wait for a video to finish rendering
      videoFormat: 'webm'
    }],
```

**From a recent build:**
<img width="1505" height="743" alt="Screenshot 2025-09-22 at 11 05 28 PM" src="https://github.com/user-attachments/assets/18cdecc8-d685-469c-af4d-1fa3977963ae" />
